### PR TITLE
Update the way for getting the inserted identity

### DIFF
--- a/SocialEventManager/src/SocialEventManager.DLL/Constants/QueryConstants.cs
+++ b/SocialEventManager/src/SocialEventManager.DLL/Constants/QueryConstants.cs
@@ -2,6 +2,6 @@ namespace SocialEventManager.DAL.Constants
 {
     public static class QueryConstants
     {
-        public const string SelectIdentity = "SELECT @@IDENTITY;";
+        public const string SelectScopeIdentity = "SELECT SCOPE_IDENTITY();";
     }
 }

--- a/SocialEventManager/src/SocialEventManager.DLL/Repositories/Users/UserRolesRepository.cs
+++ b/SocialEventManager/src/SocialEventManager.DLL/Repositories/Users/UserRolesRepository.cs
@@ -29,7 +29,7 @@ namespace SocialEventManager.DAL.Repositories.Users
                 FROM    {TableNameConstants.Roles} R
                 WHERE   R.NormalizedName = @RoleName;
 
-                {QueryConstants.SelectIdentity}";
+                {QueryConstants.SelectScopeIdentity}";
 
             return await _session.Connection.ExecuteAsync(sql, new DynamicParameters(new { userId, roleName }), _session.Transaction);
         }


### PR DESCRIPTION
It is a more accurate way to retrieve the inserted identity.
For more info, read:
https://blog.sqlauthority.com/2007/03/25/sql-server-identity-vs-scope_identity-vs-ident_current-retrieve-last-inserted-identity-of-record/