### PR TITLE
API Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Social Event Manager (SEM) is a social network for organizing events.
 
 ✔️ SignalR
 
+✔️ Versioning
+
 ❌ Authorization / Authentication
 
 ❌ Sentry
@@ -162,8 +164,6 @@ Social Event Manager (SEM) is a social network for organizing events.
 ❌ Allow media binders
 
 ❌ REST
-
-❌ Versioning
 
 ❌ [Hangfire with Redis](https://github.com/marcoCasamento/Hangfire.Redis.StackExchange)
 

--- a/SocialEventManager/shared/SocialEventManager.Shared/Constants/ApiConstants.cs
+++ b/SocialEventManager/shared/SocialEventManager.Shared/Constants/ApiConstants.cs
@@ -15,5 +15,8 @@ namespace SocialEventManager.Shared.Constants
         public const string IpRateLimitPolicies = "IpRateLimitPolicies";
         public const string Redis = "Redis";
         public const string ReceiveMessage = "ReceiveMessage";
+        public const string ApiVersion = "x-api-version";
+        public const string Version = "version";
+        public const string Ver = "ver";
     }
 }

--- a/SocialEventManager/src/SocialEventManager.API/DependencyInjection/VersionServiceCollectionExtensions.cs
+++ b/SocialEventManager/src/SocialEventManager.API/DependencyInjection/VersionServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+using SocialEventManager.Shared.Constants;
+
+namespace SocialEventManager.API.DependencyInjection
+{
+    public static class VersionServiceCollectionExtensions
+    {
+        public static IServiceCollection AddSupportedApiVersioning(this IServiceCollection services)
+        {
+            services.AddApiVersioning(options =>
+            {
+                options.AssumeDefaultVersionWhenUnspecified = true;
+                options.DefaultApiVersion = ApiVersion.Default;
+                options.ReportApiVersions = true;
+                options.ApiVersionReader = ApiVersionReader.Combine(
+                    new HeaderApiVersionReader(ApiConstants.ApiVersion),
+                    new MediaTypeApiVersionReader(ApiConstants.ApiVersion),
+                    new QueryStringApiVersionReader(ApiConstants.Ver, ApiConstants.Version));
+            });
+
+            return services;
+        }
+    }
+}

--- a/SocialEventManager/src/SocialEventManager.API/SocialEventManager.API.csproj
+++ b/SocialEventManager/src/SocialEventManager.API/SocialEventManager.API.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AspNetCoreRateLimit" Version="4.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="Hangfire" Version="1.7.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/SocialEventManager/src/SocialEventManager.API/Startup.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Startup.cs
@@ -54,8 +54,9 @@ namespace SocialEventManager.API
                     options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(
                         new[] { MimeTypeConstants.ApplicationOctetStream });
                 })
-                .AddSignalR().AddHubOptions<ChatHub>(options => options.AddFilter<ChatHubLogFilter>());
+                .AddSupportedApiVersioning();
 
+            services.AddSignalR().AddHubOptions<ChatHub>(options => options.AddFilter<ChatHubLogFilter>());
             services.AddControllers(config => config.Filters.Add(typeof(TrackActionPerformanceFilter)));
             GlobalJobFilters.Filters.Add(new HangfireElectStateEventsLogAttribute());
         }


### PR DESCRIPTION
The current API version is default, which means it is 1.0.
In order to call the APIs, provide a header or a media type key: "x-api-version".
Also "ver" is allowed instead of "version".