### PR TITLE
Refactor test methods naming

### DIFF
--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/HealthCheckTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/HealthCheckTests.cs
@@ -21,7 +21,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests
         [Theory]
         [InlineData(ApiPathConstants.HealthReady)]
         [InlineData(ApiPathConstants.HealthLive)]
-        public async Task HealthCheck_Should_Return_Ok_Status_Code(string requestUri)
+        public async Task HealthCheck_Should_ReturnOkStatusCode_When_ApplicationIsHealthy(string requestUri)
         {
             HttpResponseMessage response = await Client.GetAsync(requestUri);
             response.Should().NotBeNull();

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/RolesControllerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/RolesControllerTests.cs
@@ -32,7 +32,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests
 
         [Theory]
         [InlineAutoData]
-        public async Task CreateRole_Should_Return_Ok(ApplicationRole applicationRole)
+        public async Task CreateRole_Should_ReturnOk_When_RoleIsValid(ApplicationRole applicationRole)
         {
             applicationRole.Id = Guid.NewGuid().ToString();
 
@@ -42,7 +42,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests
 
         [Theory]
         [InlineAutoData]
-        public async Task CreateRole_DuplicateRoleName_Should_Return_BadRequest(ApplicationRole applicationRole)
+        public async Task CreateRole_Should_ReturnBadRequest_When_RoleNameIsDuplicated(ApplicationRole applicationRole)
         {
             HttpClient client = Factory.WithWebHostBuilder(builder =>
                 builder.ConfigureTestServices(services => services.AddTransient<IRolesRepository, InvalidRolesStub>()))
@@ -55,7 +55,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests
 
         [Theory]
         [MemberData(nameof(ApplicationRoleData.InvalidApplicationRole), MemberType = typeof(ApplicationRoleData))]
-        public async Task CreateRole_InvalidData_Should_Return_BadRequest(ApplicationRole applicationRole, string expectedResult)
+        public async Task CreateRole_Should_ReturnBadRequest_When_DataIsInvalid(ApplicationRole applicationRole, string expectedResult)
         {
             (HttpStatusCode statusCode, string message) = await Client.CreateAsyncWithError(ApiPathConstants.Roles, applicationRole);
             statusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/EqualityComparerTests/UserClaimEqualityComparerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/EqualityComparerTests/UserClaimEqualityComparerTests.cs
@@ -11,7 +11,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
     {
         [Theory]
         [InlineAutoData]
-        public void CompareUserClaims_Should_Return_True(UserClaim userClaim)
+        public void CompareUserClaims_Should_ReturnTrue_When_UserClaimsAreTheSame(UserClaim userClaim)
         {
             UserClaimEqualityComparer comparer = new();
             bool isEqual = comparer.Equals(userClaim, userClaim);
@@ -20,7 +20,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithDifferentIds), MemberType = typeof(UserClaimData))]
-        public void CompareUserClaims_DifferentId_Should_Return_True(UserClaim userClaim, UserClaim otherUserClaim)
+        public void CompareUserClaims_Should_ReturnTrue_When_UserClaimsHaveDifferentId(UserClaim userClaim, UserClaim otherUserClaim)
         {
             UserClaimEqualityComparer comparer = new();
             bool isEqual = comparer.Equals(userClaim, otherUserClaim);
@@ -28,7 +28,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
         }
 
         [Fact]
-        public void CompareUserClaims_BothNulls_Should_Return_True()
+        public void CompareUserClaims_Should_ReturnTrue_When_UserClaimsAreNulls()
         {
             UserClaimEqualityComparer comparer = new();
             bool isEqual = comparer.Equals(null, null);
@@ -38,7 +38,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
         [Theory]
         [InlineAutoData]
         [MemberData(nameof(UserClaimData.UserClaimsWithOneNull), MemberType = typeof(UserClaimData))]
-        public void CompareUserClaims_Should_Return_False(UserClaim userClaim, UserClaim otherUserClaim)
+        public void CompareUserClaims_Should_ReturnFalse_When_OneOfTheUserClaimsIsNull(UserClaim userClaim, UserClaim otherUserClaim)
         {
             UserClaimEqualityComparer comparer = new();
             bool isEqual = comparer.Equals(userClaim, otherUserClaim);
@@ -47,7 +47,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithDifferentIds), MemberType = typeof(UserClaimData))]
-        public void CompareUserClaims_GetHashCode_DifferentId_Should_Return_SameHash(UserClaim userClaim, UserClaim otherUserClaim)
+        public void CompareUserClaims_GetHashCode_Should_ReturnSameHash_When_UserClaimsHaveDifferentId(UserClaim userClaim, UserClaim otherUserClaim)
         {
             UserClaimEqualityComparer comparer = new();
             comparer.GetHashCode(userClaim).Should().Be(comparer.GetHashCode(otherUserClaim));
@@ -55,7 +55,7 @@ namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests
 
         [Theory]
         [InlineAutoData]
-        public void CompareUserClaims_GetHashCode_Should_Return_DifferentHash(UserClaim userClaim, UserClaim otherUserClaim)
+        public void CompareUserClaims_GetHashCode_Should_ReturnDifferentHash_When_UserClaimsAreDifferent(UserClaim userClaim, UserClaim otherUserClaim)
         {
             UserClaimEqualityComparer comparer = new();
             comparer.GetHashCode(userClaim).Should().NotBe(comparer.GetHashCode(otherUserClaim));

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/DbSessionTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/DbSessionTests.cs
@@ -21,7 +21,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
         }
 
         [Fact]
-        public void InitDbSession_OpenConnection_Should_Return_Valid_Session()
+        public void InitDbSession_Should_ReturnValidSession_When_ConnectionStringIsValid()
         {
             string connectionString = _configuration.GetConnectionString(DbConstants.SocialEventManagerTest);
             DbSession session = new(connectionString);
@@ -34,7 +34,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
         }
 
         [Fact]
-        public void InitDbSession_OpenConnection_Should_Throw_ArgumentException()
+        public void InitDbSession_Should_ThrowArgumentException_When_ConnectionStringIsInvalid()
         {
             string connectionString = RandomGeneratorHelpers.GenerateRandomValue();
             Action action = () => new DbSession(connectionString);
@@ -42,7 +42,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
         }
 
         [Fact]
-        public void InitDbSession_OpenTransaction_Should_Return_Transaction()
+        public void InitDbSession_Should_ReturnTransaction_When_TransactionHasBegun()
         {
             string connectionString = _configuration.GetConnectionString(DbConstants.SocialEventManagerTest);
             DbSession session = new(connectionString);
@@ -52,7 +52,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
         }
 
         [Fact]
-        public void InitDbSession_DisposeTransaction_Should_Return_Null_Connection()
+        public void InitDbSession_Should_ReturnNullConnection_When_ConnectionIsDisposed()
         {
             string connectionString = _configuration.GetConnectionString(DbConstants.SocialEventManagerTest);
             DbSession session = new(connectionString);

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/RedisCacheClientTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/RedisCacheClientTests.cs
@@ -17,7 +17,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
 
         [Theory]
         [InlineAutoData]
-        public async Task RedisCache_Set_Get_Delete_Should_Succeed(string key, string obj)
+        public async Task RedisCache_Set_Get_Delete_Should_Succeed_When_DataIsValid(string key, string obj)
         {
             await using IRedisClientAsync cache = await _manager.GetClientAsync();
 
@@ -33,7 +33,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
 
         [Theory]
         [InlineAutoData]
-        public async Task RedisCache_Get_Should_Return_Null(string key)
+        public async Task RedisCache_Get_Should_ReturnNull_When_KeyNotExists(string key)
         {
             await using IRedisClientAsync cache = await _manager.GetClientAsync();
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/SqlMapperUtilitiesTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/SqlMapperUtilitiesTests.cs
@@ -11,7 +11,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
     public class SqlMapperUtilitiesTests
     {
         [Fact]
-        public void GetTableName_Should_Return_TableName()
+        public void GetTableName_Should_ReturnTableName_When_ClassHasTableAttribute()
         {
             string tableName = SqlMapperUtilities.GetTableName<Role>();
             tableName.Should().Be(TableNameConstants.Roles);
@@ -22,7 +22,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
         [InlineData(typeof(Role), TableNameConstants.Roles)]
         [InlineData(typeof(UserRole), TableNameConstants.UserRoles)]
         [InlineData(typeof(UserClaim), TableNameConstants.UserClaims)]
-        public void GetTableName_ByType_Should_Return_TableName(Type type, string expectedTableName)
+        public void GetTableName_Should_ReturnTableName_When_TypeHasTableAttribute(Type type, string expectedTableName)
         {
             string actualTableName = SqlMapperUtilities.GetTableName(type);
             actualTableName.Should().Be(expectedTableName);
@@ -30,7 +30,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests
 
         [Theory]
         [InlineData(typeof(ClaimBase))]
-        public void GetTableName_ByTableNameMapper_Should_Return_TableName(Type type)
+        public void GetTableName_Should_ReturnTableName_When_TypeIsDefinedInTableNameMapper(Type type)
         {
             SqlMapperExtensions.TableNameMapper = (type) => type.Name;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/AccountsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/AccountsRepositoryTests.cs
@@ -27,7 +27,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(AccountData.AccountWithSameUserId), MemberType = typeof(AccountData))]
-        public async Task InsertDuplicateAccountUserId_Should_Throw_SqlException(IEnumerable<Account> accounts)
+        public async Task InsertAsync_Should_ThrowSqlException_When_AccountUserIdIsDuplicated(IEnumerable<Account> accounts)
         {
             Func<Task> func = async () => await Db.InsertAsync(accounts);
             string message = (await func.Should().ThrowAsync<SqlException>()).Subject.First().Message;
@@ -37,14 +37,14 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         [Theory]
         [MemberData(nameof(AccountData.AccountWithValidLength), MemberType = typeof(AccountData))]
         [MemberData(nameof(AccountData.AccountWithNonRequiredNullField), MemberType = typeof(AccountData))]
-        public async Task InsertAsync_ValidData_Should_Succeed(Account account)
+        public async Task InsertAsync_Should_Succeed_When_AccountIsValid(Account account)
         {
             await Db.InsertAsync(account);
         }
 
         [Theory]
         [MemberData(nameof(AccountData.AccountWithSameEmail), MemberType = typeof(AccountData))]
-        public async Task InsertDuplicateAccountEmail_Should_Throw_SqlException(IEnumerable<Account> accounts)
+        public async Task InsertAsync_Should_ThrowSqlException_When_AccountEmailIsDuplicated(IEnumerable<Account> accounts)
         {
             string uniqueConstraintName = $"UC_{AliasConstants.Accounts}_{nameof(Account.Email)}";
             string duplicateKeyValue = $"{accounts.First().Email}";
@@ -56,7 +56,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(AccountData.AccountWithMissingRequiredFields), MemberType = typeof(AccountData))]
-        public async Task InsertAsync_MissingRequiredFields_Should_Throw_SqlException(Account account, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RequiredFieldsAreMissing(Account account, string expectedMessage)
         {
             Func<Task> func = async () => await Db.InsertAsync(account);
             await func.Should().ThrowAsync<SqlException>().WithMessage(expectedMessage);
@@ -64,7 +64,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(AccountData.AccountWithExceededLength), MemberType = typeof(AccountData))]
-        public async Task InsertAsync_ExceedLength_Should_Throw_SqlException(Account account, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_LengthIsExceeded(Account account, string expectedMessage)
         {
             Func<Task> func = async () => await Db.InsertAsync(account);
             (await func.Should().ThrowAsync<SqlException>()).And.Message.Should().StartWith(expectedMessage);

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/ExtendedRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/ExtendedRepositoryTests.cs
@@ -32,7 +32,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Should_Return_Roles(Role role)
+        public async Task GetAsync_Should_ReturnRoles_When_FilteringByExistingRoleName(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -42,7 +42,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Should_Return_Empty_Roles(Role role)
+        public async Task GetAsync_Should_ReturnEmptyRoles_When_FilteringByNonExistingRoleName(Role role)
         {
             IEnumerable<Role> actualRoles = await Repository.GetAsync(role.Name, nameof(Role.Name));
             actualRoles.Should().BeEmpty();
@@ -50,7 +50,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByIncompatibleColumnName_Should_Throw_SqlException(Role role)
+        public async Task GetAsync_Should_ThrowSqlException_When_FilteringByIncompatibleColumnName(Role role)
         {
             Func<Task> func = async () => await Repository.GetAsync(role.Name, nameof(Role.Id));
             await func.Should().ThrowAsync<SqlException>().WithMessage(ExceptionConstants.ConversionFailedFromStringToUniqueIdentifier);
@@ -58,7 +58,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Verify_NeverCalled(Role role)
+        public async Task GetAsync_Should_VerifyNeverCalled_When_RoleNameHasDifferentValue(Role role)
         {
             await MockRepository.Object.GetAsync(role.Name, nameof(Role.Name));
             MockRepository.Verify(r => r.GetAsync($"Different {role.Name}", nameof(Role.Name)), Times.Never);
@@ -66,7 +66,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Verify_CalledOnce(Role role)
+        public async Task GetAsync_Should_VerifyCalledOnce_When_RoleNameHasSameValue(Role role)
         {
             await MockRepository.Object.GetAsync(role.Name, nameof(Role.Name));
             MockRepository.Verify(r => r.GetAsync(role.Name, nameof(Role.Name)), Times.Once);
@@ -74,7 +74,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Multiple_Should_Return_Roles(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_ReturnRoles_When_FilteringByExistingRoleNames(IEnumerable<Role> roles)
         {
             await Db.InsertAsync(roles);
 
@@ -84,7 +84,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Multiple_Should_Return_Empty_Roles(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_ReturnEmptyRoles_When_FilteringByNonExistingRoleNames(IEnumerable<Role> roles)
         {
             IEnumerable<Role> actualRoles = await Repository.GetAsync(roles.Select(role => role.Name), nameof(Role.Name));
             actualRoles.Should().BeEmpty();
@@ -92,7 +92,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByIncompatibleColumnName_Multiple_Should_Throw_SqlException(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_ThrowSqlException_When_FilteringByIncompatibleColumnNames(IEnumerable<Role> roles)
         {
             Func<Task> func = async () => await Repository.GetAsync(roles.Select(role => role.Name), nameof(Role.Id));
             await func.Should().ThrowAsync<SqlException>().WithMessage(ExceptionConstants.ConversionFailedFromStringToUniqueIdentifier);
@@ -100,7 +100,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Multiple_Verify_NeverCalled(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_VerifyNeverCalled_When_RoleNamesHaveDifferentValues(IEnumerable<Role> roles)
         {
             await MockRepository.Object.GetAsync(roles.Select(role => role.Name), nameof(Role.Name));
             MockRepository.Verify(r => r.GetAsync($"Different {roles.Select(role => role.Name)}", nameof(Role.Name)), Times.Never);
@@ -108,7 +108,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_ByColumnName_Multiple_Verify_CalledOnce(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_VerifyCalledOnce_When_RoleNamesHaveSameValues(IEnumerable<Role> roles)
         {
             IEnumerable<string> names = roles.Select(role => role.Name);
 
@@ -118,7 +118,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetSingleOrDefaultAsync_ByColumnName_Should_Return_Role(Role role)
+        public async Task GetSingleOrDefaultAsync_Should_ReturnRole_When_FilteringByExistingRoleName(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -128,7 +128,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetSingleOrDefaultAsync_ByColumnName_Should_Return_Null(Role role)
+        public async Task GetSingleOrDefaultAsync_Should_ReturnNull_When_FilteringByNonExistingRoleName(Role role)
         {
             Role actualRole = await Repository.GetSingleOrDefaultAsync(role.Name, nameof(Role.Name));
             actualRole.Should().BeNull();
@@ -136,7 +136,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetSingleOrDefaultAsync_ByIncompatibleColumnName_Should_Throw_SqlException(Role role)
+        public async Task GetSingleOrDefaultAsync_Should_ThrowSqlException_When_FilteringByIncompatibleColumnName(Role role)
         {
             Func<Task> func = async () => await Repository.GetSingleOrDefaultAsync(role.Name, nameof(Role.Id));
             await func.Should().ThrowAsync<SqlException>().WithMessage(ExceptionConstants.ConversionFailedFromStringToUniqueIdentifier);
@@ -144,7 +144,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetSingleOrDefaultAsync_ByColumnName_Verify_NeverCalled(Role role)
+        public async Task GetSingleOrDefaultAsync_Should_VerifyNeverCalled_When_RoleNameHasDifferentValue(Role role)
         {
             await MockRepository.Object.GetSingleOrDefaultAsync(role.Name, nameof(Role.Name));
             MockRepository.Verify(r => r.GetSingleOrDefaultAsync($"Different {role.Name}", nameof(Role.Name)), Times.Never);
@@ -152,7 +152,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetSingleOrDefaultAsync_ByColumnName_Verify_CalledOnce(Role role)
+        public async Task GetSingleOrDefaultAsync_Should_VerifyCalledOnce_When_RoleNameHasSameValue(Role role)
         {
             await MockRepository.Object.GetSingleOrDefaultAsync(role.Name, nameof(Role.Name));
             MockRepository.Verify(r => r.GetSingleOrDefaultAsync(role.Name, nameof(Role.Name)), Times.Once);
@@ -160,7 +160,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task DeleteAsync_ByColumnName_Should_Return_True(Role role)
+        public async Task DeleteAsync_Should_ReturnTrue_When_RoleIdExists(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -172,14 +172,14 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         }
 
         [Fact]
-        public async Task DeleteAsync_ByColumnName_Should_Return_False()
+        public async Task DeleteAsync_Should_ReturnFalse_When_RoleIdNotExists()
         {
             bool isDeleted = await Repository.DeleteAsync(Guid.NewGuid(), nameof(Role.Id));
             isDeleted.Should().BeFalse();
         }
 
         [Fact]
-        public async Task DeleteAsync_ByColumnName_Should_Throw_SqlException()
+        public async Task DeleteAsync_Should_ThrowSqlException_When_RoleIdIsInvalid()
         {
             Func<Task> func = async () => await Repository.DeleteAsync(RandomGeneratorHelpers.NextInt32(), nameof(Role.Id));
             await func.Should().ThrowAsync<SqlException>().WithMessage(ExceptionConstants.UniqueIdentifierIsIncompatibleWithInt);
@@ -187,7 +187,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteAsync_ByColumnName_Verify_NeverCalled(Guid roleId)
+        public async Task DeleteAsync_Should_VerifyNeverCalled_When_RoleIdHasDifferentValue(Guid roleId)
         {
             await MockRepository.Object.DeleteAsync(roleId, nameof(Role.Id));
             MockRepository.Verify(r => r.DeleteAsync(Guid.NewGuid(), nameof(Role.Id)), Times.Never);
@@ -195,7 +195,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteAsync_ByColumnName_Verify_CalledOnce(Guid roleId)
+        public async Task DeleteAsync_Should_VerifyCalledOnce_When_RoleIdHasSameValue(Guid roleId)
         {
             await MockRepository.Object.DeleteAsync(roleId, nameof(Role.Id));
             MockRepository.Verify(r => r.DeleteAsync(roleId, nameof(Role.Id)), Times.Once);

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/GenericRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/GenericRepositoryTests.cs
@@ -30,7 +30,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Should_Create_Role(Role role)
+        public async Task InsertAsync_Should_CreateRole_When_RoleIsValid(Role role)
         {
             await Repository.InsertAsync(role);
 
@@ -40,7 +40,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Verify_NeverCalled(Role role)
+        public async Task InsertAsync_Should_VerifyNeverCalled_When_RoleHasDifferentValue(Role role)
         {
             await MockRepository.Object.InsertAsync(role);
             MockRepository.Verify(r => r.InsertAsync(new Role()), Times.Never);
@@ -48,7 +48,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Verify_CalledOnce(Role role)
+        public async Task InsertAsync_Should_VerifyCalledOnce_When_RoleHasSameValue(Role role)
         {
             await MockRepository.Object.InsertAsync(role);
             MockRepository.Verify(r => r.InsertAsync(role), Times.Once);
@@ -56,7 +56,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Multiple_Should_Create_Roles(IEnumerable<Role> roles)
+        public async Task InsertAsync_Should_CreateRoles_When_RolesAreValid(IEnumerable<Role> roles)
         {
             await Repository.InsertAsync(roles);
 
@@ -66,7 +66,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Multiple_Verify_NeverCalled(IEnumerable<Role> roles)
+        public async Task InsertAsync_Should_VerifyNeverCalled_When_RolesHaveDifferentValue(IEnumerable<Role> roles)
         {
             await MockRepository.Object.InsertAsync(roles);
             MockRepository.Verify(r => r.InsertAsync(Enumerable.Empty<Role>()), Times.Never);
@@ -74,7 +74,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_Multiple_Verify_CalledOnce(IEnumerable<Role> roles)
+        public async Task InsertAsync_Should_VerifyCalledOnce_When_RolesHaveSameValue(IEnumerable<Role> roles)
         {
             await MockRepository.Object.InsertAsync(roles);
             MockRepository.Verify(r => r.InsertAsync(roles), Times.Once);
@@ -82,7 +82,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetAsync_Should_Return_Role(Role role)
+        public async Task GetAsync_Should_ReturnRole_When_FilteringByExistingRoleId(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -91,7 +91,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         }
 
         [Fact]
-        public async Task GetAsync_Should_Return_Null()
+        public async Task GetAsync_Should_ReturnNull_When_FilteringByNonExistingRoleId()
         {
             Role actualRole = await Repository.GetAsync(Guid.NewGuid());
             actualRole.Should().BeNull();
@@ -99,7 +99,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetAsync_Verify_NeverCalled(Guid roleId)
+        public async Task GetAsync_Should_VerifyNeverCalled_When_RoleIdHasDifferentValue(Guid roleId)
         {
             await MockRepository.Object.GetAsync(roleId);
             MockRepository.Verify(r => r.GetAsync(Guid.NewGuid()), Times.Never);
@@ -107,7 +107,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetAsync_Verify_CalledOnce(Guid roleId)
+        public async Task GetAsync_Should_VerifyCalledOnce_When_RoleIdHasSameValue(Guid roleId)
         {
             await MockRepository.Object.GetAsync(roleId);
             MockRepository.Verify(r => r.GetAsync(roleId), Times.Once);
@@ -115,7 +115,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRoles), MemberType = typeof(RoleData))]
-        public async Task GetAsync_Multiple_Should_Return_Roles(IEnumerable<Role> roles)
+        public async Task GetAsync_Should_ReturnRoles_When_RolesExist(IEnumerable<Role> roles)
         {
             await Db.InsertAsync(roles);
 
@@ -124,20 +124,20 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         }
 
         [Fact]
-        public async Task GetAsync_Multiple_Should_Return_Empty_Roles()
+        public async Task GetAsync_Should_ReturnEmptyRoles_When_RolesNotExist()
         {
             IEnumerable<Role> actualRoles = await Repository.GetAsync();
             actualRoles.Should().BeEmpty();
         }
 
         [Fact]
-        public void GetAsync_Multiple_Verify_NeverCalled()
+        public void GetAsync_Should_VerifyNeverCalled_When_MethodWasNotCalled()
         {
             MockRepository.Verify(r => r.GetAsync(), Times.Never);
         }
 
         [Fact]
-        public async Task GetAsync_Multiple_Verify_CalledOnce()
+        public async Task GetAsync_Should_VerifyCalledOnce_When_MethodCalledOnce()
         {
             await MockRepository.Object.GetAsync();
             MockRepository.Verify(r => r.GetAsync(), Times.Once);
@@ -145,7 +145,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task UpdateAsync_Should_Return_True(Role role)
+        public async Task UpdateAsync_Should_ReturnTrue_When_RoleIsValid(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -160,7 +160,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task UpdateAsync_Should_Return_False(Role role)
+        public async Task UpdateAsync_Should_ReturnFalse_When_RoleNotExists(Role role)
         {
             bool isUpdated = await Repository.UpdateAsync(role);
             isUpdated.Should().BeFalse();
@@ -168,7 +168,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task UpdateAsync_Verify_NeverCalled(Role role)
+        public async Task UpdateAsync_Should_VerifyNeverCalled_When_RoleHasDifferentValue(Role role)
         {
             await MockRepository.Object.UpdateAsync(role);
             MockRepository.Verify(r => r.UpdateAsync(null), Times.Never);
@@ -176,7 +176,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task UpdateAsync_Verify_CalledOnce(Role role)
+        public async Task UpdateAsync_Should_VerifyCalledOnce_When_RoleHasSameValue(Role role)
         {
             await MockRepository.Object.UpdateAsync(role);
             MockRepository.Verify(r => r.UpdateAsync(role), Times.Once);
@@ -184,7 +184,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task DeleteAsync_Should_Return_True(Role role)
+        public async Task DeleteAsync_Should_ReturnTrue_When_RoleExists(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -197,7 +197,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task DeleteAsync_Should_Return_False(Role role)
+        public async Task DeleteAsync_Should_ReturnFalse_When_RoleNotExists(Role role)
         {
             bool isDeleted = await Repository.DeleteAsync(role);
             isDeleted.Should().BeFalse();
@@ -205,7 +205,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task DeleteAsync_Verify_NeverCalled(Role role)
+        public async Task DeleteAsync_Should_VerifyNeverCalled_When_RoleHasDifferentValue(Role role)
         {
             await MockRepository.Object.DeleteAsync(role);
             MockRepository.Verify(r => r.DeleteAsync(null), Times.Never);
@@ -213,14 +213,14 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task DeleteAsync_Verify_CalledOnce(Role role)
+        public async Task DeleteAsync_Should_VerifyCalledOnce_When_RoleHasSameValue(Role role)
         {
             await MockRepository.Object.DeleteAsync(role);
             MockRepository.Verify(r => r.DeleteAsync(role), Times.Once);
         }
 
         [Fact]
-        public void InitializeConstructorWithNullDbSession_Should_Throw_SqlException()
+        public void InitializeConstructor_Should_ThrowSqlException_When_DbSessionIsNull()
         {
             Action action = () => new RolesRepository(null);
             action.Should().Throw<ArgumentNullException>().WithMessage(ExceptionConstants.ValueCannotBeNull("session"));

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/RolesRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/RolesRepositoryTests.cs
@@ -32,7 +32,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertRole_Should_Return_RoleId(Role role)
+        public async Task InsertRole_Should_ReturnRoleId_When_RoleIsValid(Role role)
         {
             Guid roleId = await Repository.InsertRole(role);
 
@@ -42,7 +42,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertRole_Verify_NeverCalled(Role role)
+        public async Task InsertRole_Should_VerifyNeverCalled_When_RoleHasDifferentValue(Role role)
         {
             await MockRepository.Object.InsertRole(role);
             MockRepository.Verify(r => r.InsertRole(null), Times.Never);
@@ -50,7 +50,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertRole_Verify_CalledOnce(Role role)
+        public async Task InsertRole_Should_VerifyCalledOnce_When_RoleHasSameValue(Role role)
         {
             await MockRepository.Object.InsertRole(role);
             MockRepository.Verify(r => r.InsertRole(role), Times.Once);
@@ -58,7 +58,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertDuplicateRole_Should_Throw_SqlException(Role role)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RoleIsDuplicated(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -69,7 +69,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task InsertDuplicateRoleId_Should_Throw_SqlException(Role role)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RoleIdIsDuplicated(Role role)
         {
             await Db.InsertAsync(role);
 
@@ -82,7 +82,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.RolesWithSameName), MemberType = typeof(RoleData))]
-        public async Task InsertDuplicateRoleName_Should_Throw_SqlException(IEnumerable<Role> roles)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RoleNameIsDuplicated(IEnumerable<Role> roles)
         {
             string uniqueConstraintName = $"UC_{AliasConstants.Roles}_{nameof(Role.Name)}";
             string duplicateKeyValue = roles.First().Name;
@@ -94,7 +94,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.ValidRole), MemberType = typeof(RoleData))]
-        public async Task GetByUserIdAsync_Should_Return_Roles(Role role)
+        public async Task GetByUserIdAsync_Should_ReturnRoles_When_FilteringByExistingUserWithRole(Role role)
         {
             await Db.CreateTableIfNotExistsAsync<Account>();
             await Db.CreateTableIfNotExistsAsync<UserRole>();
@@ -111,7 +111,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         }
 
         [Fact]
-        public async Task GetByUserIdAsync_Should_Return_Empty_Roles()
+        public async Task GetByUserIdAsync_Should_ReturnEmptyRoles_When_FilteringByNonExistingUser()
         {
             await Db.CreateTableIfNotExistsAsync<Account>();
             await Db.CreateTableIfNotExistsAsync<UserRole>();
@@ -121,7 +121,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         }
 
         [Fact]
-        public async Task GetByUserIdAsync_Should_Throw_SqlException()
+        public async Task GetByUserIdAsync_Should_ThrowSqlException_When_UserRoleTableWasNotCreated()
         {
             string tableName = SqlMapperUtilities.GetTableName<UserRole>();
 
@@ -131,7 +131,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetByUserIdAsync_Verify_NeverCalled(Guid userId)
+        public async Task GetByUserIdAsync_Should_VerifyNeverCalled_When_UserIdHasDifferentValue(Guid userId)
         {
             await MockRepository.Object.GetByUserIdAsync(userId);
             MockRepository.Verify(r => r.GetByUserIdAsync(Guid.NewGuid()), Times.Never);
@@ -139,7 +139,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetByUserIdAsync_Verify_CalledOnce(Guid userId)
+        public async Task GetByUserIdAsync_Should_VerifyCalledOnce_When_UserIdHasSameValue(Guid userId)
         {
             await MockRepository.Object.GetByUserIdAsync(userId);
             MockRepository.Verify(r => r.GetByUserIdAsync(userId), Times.Once);
@@ -147,14 +147,14 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.RoleWithValidLength), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_ValidData_Should_Succeed(Role role)
+        public async Task InsertAsync_Should_Succeed_When_RoleIsValid(Role role)
         {
             await Db.InsertAsync(role);
         }
 
         [Theory]
         [MemberData(nameof(RoleData.RoleWithMissingRequiredFields), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_MissingRequiredFields_Should_Throw_SqlException(Role role, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RequiredFieldsAreMissing(Role role, string expectedMessage)
         {
             Func<Task> func = async () => await Db.InsertAsync(role);
             (await func.Should().ThrowAsync<SqlException>()).WithMessage(expectedMessage);
@@ -162,7 +162,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(RoleData.RoleWithExceededLength), MemberType = typeof(RoleData))]
-        public async Task InsertAsync_ExceedLength_Should_Throw_SqlException(Role role, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_LengthIsExceeded(Role role, string expectedMessage)
         {
             Func<Task> func = async () => await Db.InsertAsync(role);
             (await func.Should().ThrowAsync<SqlException>()).And.Message.Should().StartWith(expectedMessage);

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserClaimsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserClaimsRepositoryTests.cs
@@ -31,7 +31,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.ValidUserClaim), MemberType = typeof(UserClaimData))]
-        public async Task GetUserClaims_Should_Return_UserClaims(UserClaim userClaim)
+        public async Task GetUserClaims_Should_ReturnUserClaims_When_FilteringByExistingTypeAndValue(UserClaim userClaim)
         {
             userClaim.Id = await CreateUserClaimAndRelatedData(userClaim);
 
@@ -41,7 +41,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithSameUser), MemberType = typeof(UserClaimData))]
-        public async Task GetUserClaims_Multiple_Should_Return_UserClaimPerUser(IEnumerable<UserClaim> userClaims)
+        public async Task GetUserClaims_Should_ReturnUserClaimPerUser_When_FilteringByExistingTypeAndValue(IEnumerable<UserClaim> userClaims)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaims.First().UserId));
             await Db.InsertAsync(userClaims);
@@ -55,7 +55,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithSameType), MemberType = typeof(UserClaimData))]
-        public async Task GetUserClaims_Multiple_Should_Return_UserClaimPerType(IEnumerable<UserClaim> userClaims)
+        public async Task GetUserClaims_Should_ReturnUserClaimPerType_When_FilteringByExistingTypeAndValue(IEnumerable<UserClaim> userClaims)
         {
             foreach (UserClaim userClaim in userClaims)
             {
@@ -74,7 +74,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithSameTypeAndValue), MemberType = typeof(UserClaimData))]
 
-        public async Task GetUserClaims_Multiple_Should_Return_UserClaims(IEnumerable<UserClaim> userClaims)
+        public async Task GetUserClaims_Should_ReturnUserClaims_When_FilteringByExistingTypeAndValueOfTheFirstUser(IEnumerable<UserClaim> userClaims)
         {
             foreach (UserClaim userClaim in userClaims)
             {
@@ -91,7 +91,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserClaims_Should_Return_Empty_UserClaims(string type, string value)
+        public async Task GetUserClaims_Should_ReturnEmptyUserClaims_When_FilteringByNonExistingValueOrType(string type, string value)
         {
             IEnumerable<UserClaim> actualUserClaims = await Repository.GetUserClaims(type, value);
             actualUserClaims.Should().BeEmpty();
@@ -99,7 +99,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserClaims_Verify_NeverCalled(string type, string value)
+        public async Task GetUserClaims_Should_VerifyNeverCalled_When_TypeHasDifferentValue(string type, string value)
         {
             await MockRepository.Object.GetUserClaims(type, value);
             MockRepository.Verify(r => r.GetUserClaims(null, value), Times.Never);
@@ -107,7 +107,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserClaims_Verify_CalledOnce(string type, string value)
+        public async Task GetUserClaims_Should_VerifyCalledOnce_When_TypeAndValueValuesAreRepetead(string type, string value)
         {
             await MockRepository.Object.GetUserClaims(type, value);
             MockRepository.Verify(r => r.GetUserClaims(type, value), Times.Once);
@@ -115,7 +115,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.ValidUserClaim), MemberType = typeof(UserClaimData))]
-        public async Task DeleteUserClaim_Should_Return_True(UserClaim userClaim)
+        public async Task DeleteUserClaims_Should_ReturnTrue_When_UserClaimExists(UserClaim userClaim)
         {
             userClaim.Id = await CreateUserClaimAndRelatedData(userClaim);
 
@@ -128,7 +128,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithSameUser), MemberType = typeof(UserClaimData))]
-        public async Task DeleteUserClaims_Should_Return_True(IEnumerable<UserClaim> userClaims)
+        public async Task DeleteUserClaims_Should_ReturnTrue_When_UserClaimsExist(IEnumerable<UserClaim> userClaims)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaims.First().UserId));
             await Db.InsertAsync(userClaims);
@@ -142,7 +142,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserClaims_Should_Return_False(IEnumerable<UserClaim> userClaims)
+        public async Task DeleteUserClaims_Should_ReturnFalse_When_UserClaimsNotExists(IEnumerable<UserClaim> userClaims)
         {
             bool isDeleted = await Repository.DeleteUserClaims(userClaims);
             isDeleted.Should().BeFalse();
@@ -150,7 +150,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserClaims_Verify_NeverCalled(IEnumerable<UserClaim> userClaims)
+        public async Task DeleteUserClaims_Should_VerifyNeverCalled_When_UserClaimsHaveDifferentValue(IEnumerable<UserClaim> userClaims)
         {
             await MockRepository.Object.DeleteUserClaims(userClaims);
             MockRepository.Verify(r => r.DeleteUserClaims(null), Times.Never);
@@ -158,7 +158,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserClaims_Verify_CalledOnce(IEnumerable<UserClaim> userClaims)
+        public async Task DeleteUserClaims_Should_VerifyCalledOnce_When_UserClaimsHaveSameValue(IEnumerable<UserClaim> userClaims)
         {
             await MockRepository.Object.DeleteUserClaims(userClaims);
             MockRepository.Verify(r => r.DeleteUserClaims(userClaims), Times.Once);
@@ -166,7 +166,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.ValidUserClaim), MemberType = typeof(UserClaimData))]
-        public async Task DeleteAsync_Should_Return_True(UserClaim userClaim)
+        public async Task DeleteAsync_Should_ReturnTrue_When_UserClaimExists(UserClaim userClaim)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
             int userClaimId = await Db.InsertAsync(userClaim);
@@ -180,7 +180,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimsWithSameUserAndType), MemberType = typeof(UserClaimData))]
-        public async Task InsertDuplicateUserAndTypeClaims_Should_Throw_SqlException(IEnumerable<UserClaim> userClaims)
+        public async Task InsertAsync_Should_ThrowSqlException_When_UserTypeAndClaimsAreDuplicated(IEnumerable<UserClaim> userClaims)
         {
             UserClaim firstUserClaim = userClaims.First();
             await Db.InsertAsync(AccountData.GetMockAccount(firstUserClaim.UserId));
@@ -195,7 +195,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.ValidUserClaim), MemberType = typeof(UserClaimData))]
-        public async Task InsertAsync_NonExistingUserId_Should_Throw_SqlException(UserClaim userClaim)
+        public async Task InsertAsync_Should_ThrowSqlException_When_UserIdNotExists(UserClaim userClaim)
         {
             string foriegnKeyName = $"FK_{AliasConstants.UserClaims}_{AliasConstants.Accounts}_{nameof(UserClaim.UserId)}";
             string expectedMessage = ExceptionConstants.ForeignKeyConstraintConflict(foriegnKeyName, TableNameConstants.Accounts, nameof(UserClaim.UserId));
@@ -206,7 +206,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.ValidUserClaim), MemberType = typeof(UserClaimData))]
-        public async Task DeleteUser_Should_Delete_Related_UserClaim(UserClaim userClaim)
+        public async Task DeleteUser_Should_DeleteRelatedUserClaim_When_UserHasARelatedUserClaim(UserClaim userClaim)
         {
             Account account = AccountData.GetMockAccount(userClaim.UserId);
 
@@ -221,7 +221,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimWithValidLength), MemberType = typeof(UserClaimData))]
-        public async Task InsertAsync_ValidData_Should_Succeed(UserClaim userClaim)
+        public async Task InsertAsync_Should_Succeed_When_UserClaimIsValid(UserClaim userClaim)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
             await Db.InsertAsync(userClaim);
@@ -229,7 +229,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimWithMissingRequiredFields), MemberType = typeof(UserClaimData))]
-        public async Task InsertAsync_MissingRequiredFields_Should_Throw_SqlException(UserClaim userClaim, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RequiredFieldsAreMissing(UserClaim userClaim, string expectedMessage)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
 
@@ -239,7 +239,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserClaimData.UserClaimWithExceededLength), MemberType = typeof(UserClaimData))]
-        public async Task InsertAsync_ExceedLength_Should_Throw_SqlException(UserClaim userClaim, string expectedMessage)
+        public async Task InsertAsync_Should_ThrowSqlException_When_LengthIsExceeded(UserClaim userClaim, string expectedMessage)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserRolesRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserRolesRepositoryTests.cs
@@ -31,7 +31,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task InsertAsync_Should_Return_UserRoleId(Account account, Role role)
+        public async Task InsertAsync_Should_ReturnUserRoleId_When_UserRoleIsValid(Account account, Role role)
         {
             await Db.InsertAsync(account);
             await Db.InsertAsync(role);
@@ -46,7 +46,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRole), MemberType = typeof(UserRoleData))]
-        public async Task InsertAsync_NonExistingUserId_Should_Throw_SqlException(UserRole userRole)
+        public async Task InsertAsync_Should_ThrowSqlException_When_UserIdNotExists(UserRole userRole)
         {
             await Db.InsertAsync(RoleData.GetMockRole(id: userRole.RoleId));
 
@@ -59,7 +59,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRole), MemberType = typeof(UserRoleData))]
-        public async Task InsertAsync_NonExistingRoleId_Should_Throw_SqlException(UserRole userRole)
+        public async Task InsertAsync_Should_ThrowSqlException_When_RoleIdNotExists(UserRole userRole)
         {
             await Db.InsertAsync(AccountData.GetMockAccount(userRole.UserId));
 
@@ -72,7 +72,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task InsertAsync_Verify_NeverCalled(Guid userId, string roleName)
+        public async Task InsertAsync_Should_VerifyNeverCalled_When_UserIdHasDifferentValue(Guid userId, string roleName)
         {
             await MockRepository.Object.InsertAsync(userId, roleName);
             MockRepository.Verify(r => r.InsertAsync(Guid.NewGuid(), roleName), Times.Never);
@@ -80,7 +80,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task InsertAsync_Verify_CalledOnce(Guid userId, string roleName)
+        public async Task InsertAsync_Should_VerifyCalledOnce_When_UserIdAndRoleNameValuesAreRepeated(Guid userId, string roleName)
         {
             await MockRepository.Object.InsertAsync(userId, roleName);
             MockRepository.Verify(r => r.InsertAsync(userId, roleName), Times.Once);
@@ -88,7 +88,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRole), MemberType = typeof(UserRoleData))]
-        public async Task InsertDuplicateUserRoles_Should_Throw_SqlException(UserRole userRole)
+        public async Task InsertAsync_Should_ThrowSqlException_When_UserRolesAreDuplicated(UserRole userRole)
         {
             userRole.Id = await CreateUserRoleAndRelatedData(userRole);
 
@@ -102,7 +102,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task GetUserRoles_Should_Return_UserRoles(Account account, Role role)
+        public async Task GetUserRoles_Should_ReturnUserRoles_When_FilteringByExistingRoleName(Account account, Role role)
         {
             UserRole userRole = await CreateUserRoleAndRelatedData(account, role);
 
@@ -112,7 +112,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserRoles_Should_Return_Empty_UserRoles(string roleName)
+        public async Task GetUserRoles_Should_ReturnEmptyUserRoles_When_FilteringByNonExistingRoleName(string roleName)
         {
             IEnumerable<UserRole> actualUserRoles = await Repository.GetUserRoles(roleName);
             actualUserRoles.Should().BeEmpty();
@@ -120,7 +120,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserRoles_Verify_NeverCalled(string roleName)
+        public async Task GetUserRoles_Should_VerifyNeverCalled_When_RoleNameHasDifferentValue(string roleName)
         {
             await MockRepository.Object.GetUserRoles(roleName);
             MockRepository.Verify(r => r.GetUserRoles(null), Times.Never);
@@ -128,7 +128,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task GetUserRoles_Verify_CalledOnce(string roleName)
+        public async Task GetUserRoles_Should_VerifyCalledOnce_When_RoleNameHasSameValue(string roleName)
         {
             await MockRepository.Object.GetUserRoles(roleName);
             MockRepository.Verify(r => r.GetUserRoles(roleName), Times.Once);
@@ -136,7 +136,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task DeleteUserRole_Should_Return_True(Account account, Role role)
+        public async Task DeleteUserRole_Should_ReturnTrue_When_UserRoleExists(Account account, Role role)
         {
             await CreateUserRoleAndRelatedData(account, role);
 
@@ -149,7 +149,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedDataWithMultipleRoles), MemberType = typeof(UserRoleData))]
-        public async Task DeleteUserRole_WithMultipleRoles_Should_Return_True(Account account, IEnumerable<Role> roles)
+        public async Task DeleteUserRole_Should_ReturnTrue_When_UserRolesExist(Account account, IEnumerable<Role> roles)
         {
             await Db.InsertAsync(account);
             await Db.InsertAsync(roles);
@@ -169,7 +169,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedDataWithMultipleAccounts), MemberType = typeof(UserRoleData))]
-        public async Task DeleteUserRole_WithSomeUsers_Should_Return_True(IEnumerable<Account> accounts, Role role)
+        public async Task DeleteUserRole_Should_ReturnTrue_When_UsersRolesExist(IEnumerable<Account> accounts, Role role)
         {
             await Db.InsertAsync(accounts);
             await Db.InsertAsync(role);
@@ -189,7 +189,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserRole_Should_Return_False(Guid userId, string roleName)
+        public async Task DeleteUserRole_Should_ReturnFalse_When_UserRolesNotExist(Guid userId, string roleName)
         {
             bool isDeleted = await Repository.DeleteUserRole(userId, roleName);
             isDeleted.Should().BeFalse();
@@ -197,7 +197,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserRole_Verify_NeverCalled(Guid userId, string roleName)
+        public async Task DeleteUserRole_Should_VerifyNeverCalled_When_RoleNameHasDifferentValue(Guid userId, string roleName)
         {
             await MockRepository.Object.DeleteUserRole(userId, roleName);
             MockRepository.Verify(r => r.DeleteUserRole(userId, null), Times.Never);
@@ -205,7 +205,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task DeleteUserRole_Verify_CalledOnce(Guid userId, string roleName)
+        public async Task DeleteUserRole_Should_VerifyCalledOnce_When_UserIdAndRoleNameValuesAreRepeated(Guid userId, string roleName)
         {
             await MockRepository.Object.DeleteUserRole(userId, roleName);
             MockRepository.Verify(r => r.DeleteUserRole(userId, roleName), Times.Once);
@@ -213,7 +213,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task IsInRole_Should_Return_True(Account account, Role role)
+        public async Task IsInRole_Should_ReturnTrue_When_UserWithThatRoleExists(Account account, Role role)
         {
             await CreateUserRoleAndRelatedData(account, role);
 
@@ -223,7 +223,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task IsInRole_EmptyUserRoles_Should_Return_False(Guid userId, string roleName)
+        public async Task IsInRole_Should_ReturnFalse_When_UserIdOrRoleNameNotExists(Guid userId, string roleName)
         {
             bool isInRole = await Repository.IsInRole(userId, roleName);
             isInRole.Should().BeFalse();
@@ -231,7 +231,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task IsInRole_FilterByNonExistingUserId_Should_Return_False(Account account, Role role)
+        public async Task IsInRole_Should_ReturnFalse_When_UserIdNotExists(Account account, Role role)
         {
             await CreateUserRoleAndRelatedData(account, role);
 
@@ -241,7 +241,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task IsInRole_FilterByNonExistingRoleName_Should_Return_False(Account account, Role role)
+        public async Task IsInRole_Should_ReturnFalse_When_RoleNameNotExists(Account account, Role role)
         {
             await CreateUserRoleAndRelatedData(account, role);
 
@@ -251,7 +251,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task IsInRole_Verify_NeverCalled(Guid userId, string roleName)
+        public async Task IsInRole_Should_VerifyNeverCalled_When_RoleNameHasDifferentValue(Guid userId, string roleName)
         {
             await MockRepository.Object.IsInRole(userId, roleName);
             MockRepository.Verify(r => r.IsInRole(userId, null), Times.Never);
@@ -259,7 +259,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [InlineAutoData]
-        public async Task IsInRole_Verify_CalledOnce(Guid userId, string roleName)
+        public async Task IsInRole_Should_VerifyCalledOnce_When_UserIdAndRoleNameValuesAreRepeated(Guid userId, string roleName)
         {
             await MockRepository.Object.IsInRole(userId, roleName);
             MockRepository.Verify(r => r.IsInRole(userId, roleName), Times.Once);
@@ -267,7 +267,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task DeleteUser_Should_Delete_Related_UserRole(Account account, Role role)
+        public async Task DeleteAsync_Should_DeleteRelatedUserRole_When_AccountIsDeleted(Account account, Role role)
         {
             UserRole userRole = await CreateUserRoleAndRelatedData(account, role);
             await Db.DeleteAsync(account);
@@ -278,7 +278,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests
 
         [Theory]
         [MemberData(nameof(UserRoleData.UserRoleRelatedData), MemberType = typeof(UserRoleData))]
-        public async Task DeleteRole_Should_Delete_Related_UserRole(Account account, Role role)
+        public async Task DeleteAsync_Should_DeleteRelatedUserRole_When_RoleIsDeleted(Account account, Role role)
         {
             UserRole userRole = await CreateUserRoleAndRelatedData(account, role);
             await Db.DeleteAsync(role);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/NotDefaultAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/NotDefaultAttributeTests.cs
@@ -18,7 +18,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests
         [InlineData(new[] { 1 }, true)]
         [InlineData(0, false)]
         [MemberData(nameof(GuidData.NotDefaultGuidData), MemberType = typeof(GuidData))]
-        public void IsValid_Should_Return_Expected_Result(object value, bool expectedResult)
+        public void IsValid_Should_ReturnExpectedResult(object value, bool expectedResult)
         {
             NotDefaultAttribute notDefaultAttribute = new();
             bool actualResult = notDefaultAttribute.IsValid(value);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerableExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerableExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
     {
         [Theory]
         [MemberData(nameof(EnumerableData.EmptyData), MemberType = typeof(EnumerableData))]
-        public void IsEmpty_Should_Return_Expected_Result(IEnumerable<int> enumerable, bool expectedResult)
+        public void IsEmpty_Should_ReturnExpectedResult(IEnumerable<int> enumerable, bool expectedResult)
         {
             bool actualResult = enumerable.IsEmpty();
             actualResult.Should().Be(expectedResult);
@@ -25,7 +25,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
 
         [Theory]
         [InlineData(null)]
-        public void IsEmpty_Should_Return_ArgumentNullException<T>(IEnumerable<T> enumerable)
+        public void IsEmpty_Should_ReturnArgumentNullException_When_ValueIsNull<T>(IEnumerable<T> enumerable)
         {
             Action action = () => enumerable.IsEmpty();
             action.Should().Throw<ArgumentNullException>().WithMessage(ExceptionConstants.ValueCannotBeNull("source"));
@@ -33,7 +33,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
 
         [Theory]
         [MemberData(nameof(EnumerableData.NullOrEmptyData), MemberType = typeof(EnumerableData))]
-        public void IsNullOrEmpty_Should_Return_Expected_Result(IEnumerable<int> enumerable, bool expectedResult)
+        public void IsNullOrEmpty_Should_ReturnExpectedResult(IEnumerable<int> enumerable, bool expectedResult)
         {
             bool actualResult = enumerable.IsNullOrEmpty();
             actualResult.Should().Be(expectedResult);
@@ -41,7 +41,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
 
         [Theory]
         [MemberData(nameof(EnumerableData.NotNullAndAnyData), MemberType = typeof(EnumerableData))]
-        public void IsNotNullAndAny_Should_Return_Expected_Result(IEnumerable<int> enumerable, bool expectedResult)
+        public void IsNotNullAndAny_Should_ReturnExpectedResult(IEnumerable<int> enumerable, bool expectedResult)
         {
             bool actualResult = enumerable.IsNotNullAndAny();
             actualResult.Should().Be(expectedResult);
@@ -49,7 +49,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
 
         [Theory]
         [MemberData(nameof(EnumerableData.UpdateInForEachData), MemberType = typeof(EnumerableData))]
-        public void ForEach_Should_Update_All_Values(IEnumerable<Role> roles, string roleName)
+        public void ForEach_Should_UpdateAllValues_When_RoleNameIsUpdated(IEnumerable<Role> roles, string roleName)
         {
             foreach (Role actualRole in roles.ForEach(r => r.Name = roleName))
             {

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerationExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerationExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [InlineData(RoleType.Admin, "Admin")]
         [InlineData(RoleType.User, "User")]
         [InlineData((RoleType)(-1), "-1")]
-        public void GetDescription_Should_Return_Description(Enum value, string expectedDescription)
+        public void GetDescription_Should_ReturnDescription_When_EnumHasDescriptionAttribute(Enum value, string expectedDescription)
         {
             string actualResult = value.GetDescription();
             actualResult.Should().Be(expectedDescription);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ExceptionExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ExceptionExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
     {
         [Theory]
         [MemberData(nameof(ExceptionData.ExceptionDataForHttpStatusAndTitle), MemberType = typeof(ExceptionData))]
-        public void ToHttpStatusCodeAndTitle_Should_Return_Expected_Result(Exception ex, (HttpStatusCode, string) expectedResult)
+        public void ToHttpStatusCodeAndTitle_Should_ReturnExpectedResult(Exception ex, (HttpStatusCode, string) expectedResult)
         {
             (HttpStatusCode, string) actualResult = ex.ToHttpStatusCodeAndTitle();
             actualResult.Should().Be(expectedResult);
@@ -23,7 +23,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
 
         [Theory]
         [MemberData(nameof(ExceptionData.CriticalExceptionsData), MemberType = typeof(ExceptionData))]
-        public void IsCritical_Should_Return_Expected_Result(Exception ex, bool expectedResult)
+        public void IsCritical_Should_ReturnExpectedResult(Exception ex, bool expectedResult)
         {
             bool actualResult = ex.IsCritical();
             actualResult.Should().Be(expectedResult);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/StringExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/StringExtensionsTests.cs
@@ -14,7 +14,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
     {
         [Theory]
         [MemberData(nameof(StringData.NullOrEmptyData), MemberType = typeof(StringData))]
-        public void IsNullOrEmpty_Should_Return_Expected_Result(string value, bool expectedResult)
+        public void IsNullOrEmpty_Should_ReturnExpectedResult(string value, bool expectedResult)
         {
             bool actualResult = value.IsNullOrEmpty();
             actualResult.Should().Be(expectedResult);
@@ -23,7 +23,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [Theory]
         [MemberData(nameof(StringData.NullOrEmptyData), MemberType = typeof(StringData))]
         [MemberData(nameof(StringData.WhiteSpaceData), MemberType = typeof(StringData))]
-        public void IsNullOrWhiteSpace_Should_Return_Expected_Result(string value, bool expectedResult)
+        public void IsNullOrWhiteSpace_Should_ReturnExpectedResult(string value, bool expectedResult)
         {
             bool actualResult = value.IsNullOrWhiteSpace();
             actualResult.Should().Be(expectedResult);
@@ -32,7 +32,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [Theory]
         [MemberData(nameof(StringData.TakeAfterData), MemberType = typeof(StringData))]
         [MemberData(nameof(StringData.TakeAfterFirstData), MemberType = typeof(StringData))]
-        public void TaskAfterFirst_Should_Return_Partial_Value(string value, string fromStart, StringComparison comparisonType, string expectedValue)
+        public void TaskAfterFirst_Should_ReturnPartialValue_When_ValueExists(string value, string fromStart, StringComparison comparisonType, string expectedValue)
         {
             string actualResult = value.TakeAfterFirst(fromStart, comparisonType);
             actualResult.Should().Be(expectedValue);
@@ -41,7 +41,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [Theory]
         [MemberData(nameof(StringData.TakeAfterData), MemberType = typeof(StringData))]
         [MemberData(nameof(StringData.TakeAfterLastData), MemberType = typeof(StringData))]
-        public void TaskAfterLast_Should_Return_Partial_Value(string value, string fromStart, StringComparison comparisonType, string expectedValue)
+        public void TaskAfterLast_Should_ReturnPartialValue_When_ValueExists(string value, string fromStart, StringComparison comparisonType, string expectedValue)
         {
             string actualResult = value.TakeAfterLast(fromStart, comparisonType);
             actualResult.Should().Be(expectedValue);
@@ -50,7 +50,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [Theory]
         [MemberData(nameof(StringData.TakeUntilData), MemberType = typeof(StringData))]
         [MemberData(nameof(StringData.TakeUntilFirstData), MemberType = typeof(StringData))]
-        public void TaskUntilFirst_Should_Return_Partial_Value(string value, string fromEnd, StringComparison comparisonType, string expectedValue)
+        public void TaskUntilFirst_Should_ReturnPartialValue_When_ValueExists(string value, string fromEnd, StringComparison comparisonType, string expectedValue)
         {
             string actualResult = value.TakeUntilFirst(fromEnd, comparisonType);
             actualResult.Should().Be(expectedValue);
@@ -59,7 +59,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         [Theory]
         [MemberData(nameof(StringData.TakeUntilData), MemberType = typeof(StringData))]
         [MemberData(nameof(StringData.TakeUntilLastData), MemberType = typeof(StringData))]
-        public void TaskUntilLast_Should_Return_Partial_Value(string value, string fromEnd, StringComparison comparisonType, string expectedValue)
+        public void TaskUntilLast_Should_ReturnPartialValue_When_ValueExists(string value, string fromEnd, StringComparison comparisonType, string expectedValue)
         {
             string actualResult = value.TakeUntilLast(fromEnd, comparisonType);
             actualResult.Should().Be(expectedValue);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/TypeExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/TypeExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
     public class TypeExtensionsTests
     {
         [Fact]
-        public void GetNonPublicStaticMethod_Should_Return_Method()
+        public void GetNonPublicStaticMethod_Should_ReturnMethod_When_MethodNameExists()
         {
             const string methodName = "GetTableName";
             MethodInfo getTableNameMethod = typeof(SqlMapperExtensions).GetNonPublicStaticMethod(methodName);
@@ -21,7 +21,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests
         }
 
         [Fact]
-        public void GetNonPublicStaticMethod_Should_Return_ArgumentOutOfRangeException()
+        public void GetNonPublicStaticMethod_Should_ReturnArgumentOutOfRangeException_When_MethodNameDoesNotExist()
         {
             string methodName = RandomGeneratorHelpers.GenerateRandomValue();
             Type type = typeof(SqlMapperExtensions);

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/RandomGeneratorHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/RandomGeneratorHelpersTests.cs
@@ -13,7 +13,7 @@ namespace SocialEventManager.Tests.UnitTests.HelperTests
     {
         [Theory]
         [InlineAutoData]
-        public void GenerateRandomValue_Should_Return_Value_Of_Requested_Length(int length)
+        public void GenerateRandomValue_Should_ReturnValueOfRequestedLength_When_LengthIsPositive(int length)
         {
             string value = RandomGeneratorHelpers.GenerateRandomValue(length);
             value.Length.Should().Be(length);


### PR DESCRIPTION
The new tests convention is:

**MethodName_Should_ExpectedBehavior_When_StateUnderTest**

This convention is taken from the [7 unit test naming](https://dzone.com/articles/7-popular-unit-test-naming) article, where I liked the most option 5 and added the tested method name at the beginning of the test name.