### PR TITLE
Fix pull-dog warning regarding a missing docker-compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,7 @@ ServiceFabricBackup/
 *.rptproj.bak
 *.yml.bak
 README.md.bak
+pull-dog.json.bak
 
 # SQL Server files
 *.mdf

--- a/pull-dog.json
+++ b/pull-dog.json
@@ -1,0 +1,5 @@
+{
+    "dockerComposeYmlFilePaths": [
+        "SocialEventManager/docker-compose.yml"
+    ]
+}


### PR DESCRIPTION
[Pull Dog](https://dogger.io/) is an automated test environment created from the docker-compose.yml file for every opened pull request.

If the docker-compose file is not in the root level, pull-dog should be notified about the path to this file.

For more info https://dogger.io/documentation#customizing-pull-dog-for-a-repository.