### PR TITLE
Fix sonarcloud smell codes

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/Controllers/AccountsController.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Controllers/AccountsController.cs
@@ -95,11 +95,14 @@ public class AccountsController : ControllerBase
     {
         SignInResult result = await _signInManager.PasswordSignInAsync(loginModel.UserName, loginModel.Password, isPersistent: true, lockoutOnFailure: false);
 
-        return result.IsLockedOut
-            ? Unauthorized()
-            : result.Succeeded
-                ? Ok()
-                : BadRequest();
+        if (result.IsLockedOut)
+        {
+            return Unauthorized();
+        }
+
+        return result.Succeeded
+            ? Ok()
+            : BadRequest();
     }
 
     /// <summary>

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Accounts/AccountsService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Accounts/AccountsService.cs
@@ -102,8 +102,6 @@ public class AccountsService : ServiceBase<IAccountsRepository, Account>, IAccou
         {
             throw new NotFoundException($"The user '{userId}' {ValidationConstants.WasNotFound}");
         }
-
-        return;
     }
 
     #endregion Private Methods

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Infrastructure/ServiceBase.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Infrastructure/ServiceBase.cs
@@ -55,7 +55,7 @@ public class ServiceBase<TIRepository, TEntity>
         Logger = logger;
     }
 
-    protected TIRepository Repository { get; } = null!;
+    protected TIRepository Repository { get; }
 
     protected IUnitOfWork UnitOfWork { get; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Roles/RolesService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Roles/RolesService.cs
@@ -71,8 +71,6 @@ public class RolesService : ServiceBase<IRolesRepository, Role>, IRolesService
         {
             throw new NotFoundException($"The role '{roleId}' {ValidationConstants.WasNotFound}");
         }
-
-        return;
     }
 
     #endregion Private Methods

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Users/UserClaimsService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Users/UserClaimsService.cs
@@ -22,8 +22,6 @@ public class UserClaimsService : ServiceBase<IUserClaimsRepository, UserClaim>, 
     {
         IEnumerable<UserClaim> userClaims = Mapper.Map<IEnumerable<UserClaim>>(userClaimsForCreation);
         await Repository.InsertAsync(userClaims);
-
-        return;
     }
 
     public async Task<IEnumerable<UserClaimDto>> GetUserClaims(Guid userId)

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Users/UserRolesService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Users/UserRolesService.cs
@@ -60,8 +60,6 @@ public class UserRolesService : ServiceBase<IUserRolesRepository, UserRole>, IUs
         {
             throw new NotFoundException($"User '{userId}' role '{roleName}' {ValidationConstants.WasNotFound}");
         }
-
-        return;
     }
 
     #endregion Private Methods

--- a/SocialEventManager/src/SocialEventManager.DLL/Infrastructure/DbSession.cs
+++ b/SocialEventManager/src/SocialEventManager.DLL/Infrastructure/DbSession.cs
@@ -11,7 +11,7 @@ public sealed class DbSession : IDbSession, IDisposable
         Connection.Open();
     }
 
-    public IDbConnection Connection { get; } = null!;
+    public IDbConnection Connection { get; }
 
     public IDbTransaction Transaction { get; set; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireClientEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireClientEventsLogAttribute.cs
@@ -8,16 +8,16 @@ public class HangfireClientEventsLogAttribute : JobFilterAttribute, IClientFilte
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
-    public void OnCreating(CreatingContext context)
+    public void OnCreating(CreatingContext filterContext)
     {
-        Logger.InfoFormat("IClientFilter: Creating a job based on method `{0}`...", context.Job.Method.Name);
+        Logger.InfoFormat("IClientFilter: Creating a job based on method `{0}`...", filterContext.Job.Method.Name);
     }
 
-    public void OnCreated(CreatedContext context)
+    public void OnCreated(CreatedContext filterContext)
     {
         Logger.InfoFormat(
             "IClientFilter: Job that is based on method `{0}` has been created with id `{1}`",
-            context.Job.Method.Name,
-            context.BackgroundJob?.Id);
+            filterContext.Job.Method.Name,
+            filterContext.BackgroundJob?.Id);
     }
 }

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireServerEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireServerEventsLogAttribute.cs
@@ -8,13 +8,13 @@ public class HangfireServerEventsLogAttribute : JobFilterAttribute, IServerFilte
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
-    public void OnPerforming(PerformingContext context)
+    public void OnPerforming(PerformingContext filterContext)
     {
-        Logger.InfoFormat("IServerFilter: Starting to perform job `{0}`", context.BackgroundJob.Id);
+        Logger.InfoFormat("IServerFilter: Starting to perform job `{0}`", filterContext.BackgroundJob.Id);
     }
 
-    public void OnPerformed(PerformedContext context)
+    public void OnPerformed(PerformedContext filterContext)
     {
-        Logger.InfoFormat("IServerFilter: Job `{0}` has been performed", context.BackgroundJob.Id);
+        Logger.InfoFormat("IServerFilter: Job `{0}` has been performed", filterContext.BackgroundJob.Id);
     }
 }

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Loggers/LogMessages.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Loggers/LogMessages.cs
@@ -4,13 +4,8 @@ namespace SocialEventManager.Infrastructure.Loggers;
 
 public static class LogMessages
 {
-    private static readonly Action<ILogger, string, string, long, Exception> _routePerformance;
-
-    static LogMessages()
-    {
-        _routePerformance = LoggerMessage.Define<string, string, long>(
-            LogLevel.Information, 0, "{RouteName} {Method} code took {ElapsedMilliseconds}.");
-    }
+    private static readonly Action<ILogger, string, string, long, Exception> _routePerformance =
+        LoggerMessage.Define<string, string, long>(LogLevel.Information, 0, "{RouteName} {Method} code took {ElapsedMilliseconds}.");
 
     public static void LogRoutePerformance(this ILogger logger, string pageName, string method,
         long elapsedMilliseconds)

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiErrorData.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiErrorData.cs
@@ -13,7 +13,7 @@ public class ApiErrorData
         Links = links;
     }
 
-    public string Detail { get; set; } = null!;
+    public string Detail { get; set; }
 
     public string Links { get; set; } = null!;
 }

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Infrastructure/TestBase.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Infrastructure/TestBase.cs
@@ -12,6 +12,12 @@ public class TestBase : IDisposable
     public void Dispose()
     {
         Db.CleanupAsync().GetAwaiter().GetResult();
+
+        Dispose(true);
         GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
     }
 }

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/AccountsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/AccountsRepositoryTests.cs
@@ -35,7 +35,8 @@ public class AccountsRepositoryTests : RepositoryTestBase<IAccountsRepository, A
     [MemberData(nameof(AccountData.AccountWithNonRequiredNullField), MemberType = typeof(AccountData))]
     public async Task InsertAsync_Should_Succeed_When_AccountIsValid(Account account)
     {
-        await Db.InsertAsync(account);
+        int id = await Db.InsertAsync(account);
+        Assert.True(id > 0);
     }
 
     [Theory]

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/RolesRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/RolesRepositoryTests.cs
@@ -145,7 +145,8 @@ public class RolesRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
     [MemberData(nameof(RoleData.RoleWithValidLength), MemberType = typeof(RoleData))]
     public async Task InsertAsync_Should_Succeed_When_RoleIsValid(Role role)
     {
-        await Db.InsertAsync(role);
+        int id = await Db.InsertAsync(role);
+        Assert.True(id > 0);
     }
 
     [Theory]

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserClaimsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/UserClaimsRepositoryTests.cs
@@ -218,8 +218,11 @@ public class UserClaimsRepositoryTests : RepositoryTestBase<IUserClaimsRepositor
     [MemberData(nameof(UserClaimData.UserClaimWithValidLength), MemberType = typeof(UserClaimData))]
     public async Task InsertAsync_Should_Succeed_When_UserClaimIsValid(UserClaim userClaim)
     {
-        await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
-        await Db.InsertAsync(userClaim);
+        int accountId = await Db.InsertAsync(AccountData.GetMockAccount(userClaim.UserId));
+        int userClaimId = await Db.InsertAsync(userClaim);
+
+        Assert.True(accountId > 0);
+        Assert.True(userClaimId > 0);
     }
 
     [Theory]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentExceptionHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentExceptionHelpersTests.cs
@@ -17,7 +17,8 @@ public class ArgumentExceptionHelpersTests
     [InlineAutoData]
     public void ThrowIfNullOrEmpty_Should_NotThrowArgumentException_When_ArgumentHasValue(IEnumerable<object> argument)
     {
-        ArgumentExceptionHelpers.ThrowIfNullOrEmpty(argument, nameof(argument));
+        Exception? exception = Record.Exception(() => ArgumentExceptionHelpers.ThrowIfNullOrEmpty(argument, nameof(argument)));
+        Assert.Null(exception);
     }
 
     [Theory]


### PR DESCRIPTION
Fixed the following code smells:

- Extract this nested ternary operation into an independent statement
- Initialize all 'static fields' inline and remove the 'static constructor'
- Remove this redundant jump (redundant return in a void/Task method)
- Fix this implementation of 'IDisposable' to conform to the dispose pattern
- Remove the default parameter value to match the signature of overridden method
- Split this method into two, one handling parameters check and the other handling the asynchronous code
- The parameter name 'Id' is not declared in the argument listt
- Update this method so that its implementation is not identical to 'MethodName'
- Remove the member initializer, all constructors set an initial value for the member
- Rename parameter 'context' to 'filterContext' to match the interface declaration
- Initialize all 'static fields' inline and remove the 'static constructor'
- Add at least one assertion to this test case