### PR TITLE
Add Guid extensions for encoding and decoding base 64

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/SocialEventManager.API.xml
+++ b/SocialEventManager/src/SocialEventManager.API/SocialEventManager.API.xml
@@ -11,13 +11,13 @@
         </member>
         <member name="M:SocialEventManager.API.Controllers.ContactController.#ctor(SocialEventManager.BLL.Services.Contact.IContactService)">
             <summary>
-            Initializes a new instance of the <see cref="T:SocialEventManager.API.Controllers.ContactController" /> class.
+            Initializes a new instance of the <see cref="T:SocialEventManager.API.Controllers.ContactController"/> class.
             </summary>
             <param name="contactService">Contact us service.</param>
         </member>
         <member name="M:SocialEventManager.API.Controllers.ContactController.Post(SocialEventManager.Shared.Models.Contact.ContactDto)">
             <summary>
-            Sends an email to <see cref="F:SocialEventManager.Shared.Constants.ContactConstants.Email" />.
+            Sends an email to <see cref="F:SocialEventManager.Shared.Constants.ContactConstants.Email"/>.
             </summary>
             <param name="contact">Requested information for contacting us.</param>
             <returns>An empty ActionResult.</returns>

--- a/SocialEventManager/src/SocialEventManager.Shared/Extensions/GuidExtensions.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Extensions/GuidExtensions.cs
@@ -1,0 +1,64 @@
+using System.Buffers.Text;
+using System.Runtime.InteropServices;
+
+namespace SocialEventManager.Shared.Extensions;
+
+public static class GuidExtensions
+{
+    private const char Dash = '-';
+    private const char EqualsChar = '=';
+    private const byte ForwardSlashByte = (byte)Slash;
+    private const char Plus = '+';
+    private const byte PlusByte = (byte)Plus;
+    private const char Slash = '/';
+    private const char Underscore = '_';
+    private const int Base64LengthWithoutEquals = 22;
+
+    public static string EncodeBase64String(this Guid guid)
+    {
+        Span<byte> guidBytes = stackalloc byte[16];
+        Span<byte> encodedBytes = stackalloc byte[24];
+
+        MemoryMarshal.TryWrite(guidBytes, ref guid);
+        Base64.EncodeToUtf8(guidBytes, encodedBytes, out _, out _);
+
+        Span<char> chars = stackalloc char[Base64LengthWithoutEquals];
+
+        // Replace any characters which are not URL safe.
+        // And skip the final two bytes as these will be '==' padding we don't need.
+        for (int i = 0; i < Base64LengthWithoutEquals; i++)
+        {
+            chars[i] = encodedBytes[i] switch
+            {
+                ForwardSlashByte => Dash,
+                PlusByte => Underscore,
+                _ => (char)encodedBytes[i],
+            };
+        }
+
+        return new(chars);
+    }
+
+    public static Guid DecodeBase64String(this ReadOnlySpan<char> id)
+    {
+        Span<char> base64Chars = stackalloc char[24];
+
+        for (var i = 0; i < Base64LengthWithoutEquals; i++)
+        {
+            base64Chars[i] = id[i] switch
+            {
+                Dash => Slash,
+                Underscore => Plus,
+                _ => id[i],
+            };
+        }
+
+        base64Chars[22] = EqualsChar;
+        base64Chars[23] = EqualsChar;
+
+        Span<byte> idBytes = stackalloc byte[16];
+        Convert.TryFromBase64Chars(base64Chars, idBytes, out _);
+
+        return new(idBytes);
+    }
+}

--- a/SocialEventManager/src/SocialEventManager.Shared/SocialEventManager.Shared.projitems
+++ b/SocialEventManager/src/SocialEventManager.Shared/SocialEventManager.Shared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Enums\UserLoginResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EqualityComparers\Obsolete\UserClaimEqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EnumerationExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\GuidExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\HttpClientExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Obsolete\IdentityErrorExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SignInResultExtensions.cs" />

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/GuidExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/GuidExtensionsTests.cs
@@ -1,0 +1,44 @@
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using SocialEventManager.Shared.Constants;
+using SocialEventManager.Shared.Extensions;
+using Xunit;
+using Xunit.Categories;
+
+namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
+
+[UnitTest]
+[Category(CategoryConstants.Extensions)]
+public class GuidExtensionsTests
+{
+    private const int Base64LengthWithoutEquals = 22;
+    private const string EmptyBase64 = "AAAAAAAAAAAAAAAAAAAAAA";
+
+    [Theory]
+    [AutoData]
+    public void EncodeBase64String_DecodeBase64String_Should_ReturnInitialGuid_When_Called(Guid guid)
+    {
+        string actualBase64 = guid.EncodeBase64String();
+        actualBase64.Should().NotBe(string.Empty)
+            .And.HaveLength(Base64LengthWithoutEquals);
+
+        Guid actualGuid = ((ReadOnlySpan<char>)actualBase64).DecodeBase64String();
+        actualGuid.Should().Be(guid);
+    }
+
+    [Theory]
+    [InlineData(EmptyBase64)]
+    public void EncodeBase64String_Should_ReturnEmptyBase64_When_GuidIsEmpty(string expected)
+    {
+        string actualBase64 = Guid.Empty.EncodeBase64String();
+        actualBase64.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(EmptyBase64)]
+    public void DecodeBase64String_Should_ReturnEmptyGuid_When_StringIsEmptyBase64(string base64)
+    {
+        Guid actual = ((ReadOnlySpan<char>)base64).DecodeBase64String();
+        actual.Should().Be(Guid.Empty);
+    }
+}


### PR DESCRIPTION
The methods are implemented by using Spans for an optimized code and high-performance.

For more info read about [Spans](https://www.stevejgordon.co.uk/an-introduction-to-optimising-code-using-span-t) and using [high-performance techniques to encode and decode a Guid](https://www.stevejgordon.co.uk/using-high-performance-dotnetcore-csharp-techniques-to-base64-encode-a-guid).
Also, very helpful [video explanation](https://www.youtube.com/watch?v=B2yOjLyEZk0).