### PR TITLE
Stop using string interpolation in log message templates

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHub.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHub.cs
@@ -8,7 +8,7 @@ public class ChatHub : Hub
 {
     public async Task SendMessage(Guid userId, string message)
     {
-        Log.Information($"User '{userId}' receive message '{message}'");
+        Log.Information("User '{userId}' receive message '{message}'", userId, message);
         await Clients.All.SendAsync(ApiConstants.ReceiveMessage, userId, message);
     }
 }

--- a/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHubLogFilter.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHubLogFilter.cs
@@ -9,7 +9,7 @@ public class ChatHubLogFilter : IHubFilter
     public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
     {
         string message = JsonConvert.SerializeObject(invocationContext.HubMethodArguments);
-        Log.Information($"Conversation message: '{message}'");
+        Log.Information("Conversation message: '{message}'", message);
 
         return await next(invocationContext);
     }

--- a/SocialEventManager/src/SocialEventManager.DAL/Migrations/EnumLookupTableCreator.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Migrations/EnumLookupTableCreator.cs
@@ -23,7 +23,7 @@ public class EnumLookupTableCreator
 
     public async Task Run()
     {
-        Log.Debug($"[{_connection.Database}]: Checking for {SchemaConstants.Enum}...");
+        Log.Debug("[{Database}]: Checking for {SchemaConstants.Enum}...", _connection.Database, SchemaConstants.Enum);
 
         await EnsureSchemaExists();
         HashSet<string> enumTableNames = await GetEnumTableNames();
@@ -33,7 +33,7 @@ public class EnumLookupTableCreator
 
         await Task.WhenAll(upsertLookupTasks);
 
-        Log.Debug($"[{_connection.Database}]: Synced all platform enum tables.");
+        Log.Debug("[{Database}]: Synced all platform enum tables.", _connection.Database);
     }
 
     #region Private Methods
@@ -46,19 +46,19 @@ public class EnumLookupTableCreator
 
     private async Task CreateSchemaIfNotExists()
     {
-        Log.Debug($"[{_connection.Database}]: Checking for {SchemaConstants.Enum}...");
+        Log.Debug("[{Database}]: Checking for {Enum}...", _connection.Database, SchemaConstants.Enum);
 
         int rowCount = await _connection.ExecuteScalarAsync<int>(SchemaQueryHelpers.CreateSchemaIfNotExists(SchemaConstants.Enum));
 
         if (rowCount == 1)
         {
-            Log.Debug($"[{_connection.Database}]: Created schema {SchemaConstants.Enum}.");
+            Log.Debug("[{Database}]: Created schema {Enum}.", _connection.Database, SchemaConstants.Enum);
         }
     }
 
     private async Task RecreateType()
     {
-        Log.Debug($"[{_connection.Database}]: Recreating {SchemaConstants.Enum}.{TypeName}...");
+        Log.Debug("[{Database}]: Recreating {Enum}.{TypeName}...", _connection.Database, SchemaConstants.Enum, TypeName);
         await _connection.ExecuteNonQueryAsync(TableQueryHelpers.RecreateType(SchemaConstants.Enum, TypeName));
     }
 
@@ -126,12 +126,12 @@ public class EnumLookupTableCreator
 
     private async Task CreateTable(string tableName)
     {
-        Log.Debug($"[{_connection.Database}]: Creating table {SchemaConstants.Enum}.{tableName}...");
+        Log.Debug("[{Database}]: Creating table {Enum}.{tableName}...", _connection.Database, SchemaConstants.Enum, tableName);
 
         string command = TableQueryHelpers.CreateBasicTable(SchemaConstants.Enum, tableName);
         await _connection.ExecuteNonQueryAsync(command);
 
-        Log.Debug($"[{_connection.Database}]: Created table {SchemaConstants.Enum}.{tableName}.");
+        Log.Debug("[{Database}]: Created table {SchemaConstants.Enum}.{tableName}.", _connection.Database, SchemaConstants.Enum, tableName);
     }
 
     private void MergeValues(Type type, string tableName)
@@ -171,7 +171,7 @@ public class EnumLookupTableCreator
 
         cmd.ExecuteNonQuery();
 
-        Log.Debug($"Synced enums values for {tableName}.");
+        Log.Debug("Synced enums values for {tableName}.", tableName);
     }
 
     #endregion Private Methods

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionMiddleware.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionMiddleware.cs
@@ -49,7 +49,7 @@ public class ApiExceptionMiddleware
         string message = GetInnermostExceptionMessage(ex);
 
         LogEventLevel level = _options.DetermineLogLevel?.Invoke(ex) ?? LogEventLevel.Error;
-        Log.Write(level, ex, $"{ExceptionConstants.AnErrorOccurred}: {message} -- {error.Id}.");
+        Log.Write(level, ex, "{AnErrorOccurred}: {message} -- {error.Id}.", ExceptionConstants.AnErrorOccurred, message, error.Id);
 
         string result = JsonConvert.SerializeObject(error);
         context.Response.ContentType = MediaTypeConstants.ApplicationJson;

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Helpers/EmailHelpers.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Helpers/EmailHelpers.cs
@@ -25,7 +25,7 @@ internal static class EmailHelpers
                     || ex.Message == ExceptionConstants.ConnectionRefused
                     || ex.Message == ExceptionConstants.CannotAssignRequestedAddress)
             {
-                Log.Information($"Email SMTP server does not set for port {port}.");
+                Log.Information("Email SMTP server does not set for port {port}.", port);
             }
         }
     }


### PR DESCRIPTION
Surprisingly there is a difference between interpolated data to passing the variables as parameters to the log method. Behind the scenes, the parameters allow filters, add logs of flexibility, export into data lakes for further analysis, and more.

A great [video](https://chess24.com/en/watch/live-tournaments/champions-showdown-chess-9lx-2022/11/1/1) explanation by Nick Chapsas.