### PR TITLE
Add sealed to classes that should not be inherited

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/Controllers/AccountsController.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Controllers/AccountsController.cs
@@ -13,7 +13,7 @@ namespace SocialEventManager.API.Controllers;
 [ApiVersion("1.0")]
 [Consumes(MediaTypeConstants.ApplicationJson)]
 [AllowAnonymous]
-public class AccountsController : ControllerBase
+public sealed class AccountsController : ControllerBase
 {
     private readonly IAuthService _authService;
 

--- a/SocialEventManager/src/SocialEventManager.API/Controllers/ContactController.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Controllers/ContactController.cs
@@ -14,7 +14,7 @@ namespace SocialEventManager.API.Controllers;
 [ApiVersion("1.0")]
 [Consumes(MediaTypeConstants.ApplicationJson)]
 [AllowAnonymous]
-public class ContactController : ControllerBase
+public sealed class ContactController : ControllerBase
 {
     private readonly IContactService _contactService;
 

--- a/SocialEventManager/src/SocialEventManager.API/Controllers/Obsolete/AccountsController.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Controllers/Obsolete/AccountsController.cs
@@ -25,7 +25,7 @@ using Microsoft.AspNetCore.Identity;
 [Route(ApiPathConstants.ApiController)]
 [ApiVersion("1.0")]
 [Consumes(MediaTypeConstants.ApplicationJson)]
-public class AccountsController : ControllerBase
+public sealed class AccountsController : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly SignInManager<ApplicationUser> _signInManager;

--- a/SocialEventManager/src/SocialEventManager.API/Controllers/Obsolete/RolesController.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Controllers/Obsolete/RolesController.cs
@@ -19,7 +19,7 @@ namespace SocialEventManager.API.Controllers;
 [Route(ApiPathConstants.ApiController)]
 [ApiVersion("1.0")]
 [Consumes(MediaTypeConstants.ApplicationJson)]
-public class RolesController : ControllerBase
+public sealed class RolesController : ControllerBase
 {
     private readonly RoleManager<ApplicationRole> _roleManager;
 

--- a/SocialEventManager/src/SocialEventManager.API/DependencyInjection/SlugifyParameterTransformer.cs
+++ b/SocialEventManager/src/SocialEventManager.API/DependencyInjection/SlugifyParameterTransformer.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace SocialEventManager.API.DependencyInjection;
 
-public class SlugifyParameterTransformer : IOutboundParameterTransformer
+public sealed class SlugifyParameterTransformer : IOutboundParameterTransformer
 {
     public string? TransformOutbound(object? value)
     {

--- a/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHub.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHub.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Constants;
 
 namespace SocialEventManager.API.Hubs;
 
-public class ChatHub : Hub
+public sealed class ChatHub : Hub
 {
     public async Task SendMessage(Guid userId, string message)
     {

--- a/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHubLogFilter.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Hubs/ChatHubLogFilter.cs
@@ -4,7 +4,7 @@ using Serilog;
 
 namespace SocialEventManager.API.Hubs;
 
-public class ChatHubLogFilter : IHubFilter
+public sealed class ChatHubLogFilter : IHubFilter
 {
     public async ValueTask<object?> InvokeMethodAsync(HubInvocationContext invocationContext, Func<HubInvocationContext, ValueTask<object?>> next)
     {

--- a/SocialEventManager/src/SocialEventManager.API/Utilities/Attributes/RequestHeaderMatchesMediaTypeAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Utilities/Attributes/RequestHeaderMatchesMediaTypeAttribute.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Shared.Helpers;
 namespace SocialEventManager.API.Utilities.Attributes;
 
 [AttributeUsage(AttributeTargets.All, Inherited = true, AllowMultiple = true)]
-public class RequestHeaderMatchesMediaTypeAttribute : Attribute, IActionConstraint
+public sealed class RequestHeaderMatchesMediaTypeAttribute : Attribute, IActionConstraint
 {
     private readonly MediaTypeCollection _mediaTypes = new();
     private readonly string _requestHeaderToMatch;

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ApplicationUserValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ApplicationUserValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class ApplicationUserValidator : AbstractValidator<ApplicationUser>
+public sealed class ApplicationUserValidator : AbstractValidator<ApplicationUser>
 {
     public ApplicationUserValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ConfirmEmailDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ConfirmEmailDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class ConfirmEmailDtoValidator : AbstractValidator<ConfirmEmailDto>
+public sealed class ConfirmEmailDtoValidator : AbstractValidator<ConfirmEmailDto>
 {
     public ConfirmEmailDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ForgotPasswordDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ForgotPasswordDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class ForgotPasswordDtoValidator : AbstractValidator<ForgotPasswordDto>
+public sealed class ForgotPasswordDtoValidator : AbstractValidator<ForgotPasswordDto>
 {
     public ForgotPasswordDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ResetPasswordDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/ResetPasswordDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class ResetPasswordDtoValidator : AbstractValidator<ResetPasswordDto>
+public sealed class ResetPasswordDtoValidator : AbstractValidator<ResetPasswordDto>
 {
     public ResetPasswordDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/UserLoginDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/UserLoginDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class UserLoginDtoValidator : AbstractValidator<UserLoginDto>
+public sealed class UserLoginDtoValidator : AbstractValidator<UserLoginDto>
 {
     public UserLoginDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Auth/UserRegistrationDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Auth/UserRegistrationDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.API.Validations.Auth;
 
-public class UserRegistrationDtoValidator : AbstractValidator<UserRegistrationDto>
+public sealed class UserRegistrationDtoValidator : AbstractValidator<UserRegistrationDto>
 {
     public UserRegistrationDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.API/Validations/Contact/ContactDtoValidator.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Validations/Contact/ContactDtoValidator.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Models.Contact;
 
 namespace SocialEventManager.API.Validations.Contact;
 
-public class ContactDtoValidator : AbstractValidator<ContactDto>
+public sealed class ContactDtoValidator : AbstractValidator<ContactDto>
 {
     public ContactDtoValidator()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/ContactProfile.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/ContactProfile.cs
@@ -5,7 +5,7 @@ using SocialEventManager.Shared.Models.Email;
 
 namespace SocialEventManager.BLL.MappingProfiles;
 
-public class ContactProfile : Profile
+public sealed class ContactProfile : Profile
 {
     public ContactProfile()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/IdentityProfile.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/IdentityProfile.cs
@@ -3,7 +3,7 @@ using SocialEventManager.Shared.Models.Auth;
 
 namespace SocialEventManager.BLL.MappingConfigurations;
 
-public class IdentityProfile : Profile
+public sealed class IdentityProfile : Profile
 {
     public IdentityProfile()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/AccountProfile.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/AccountProfile.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Shared.Models.Identity;
 
 namespace SocialEventManager.BLL.MappingProfiles;
 
-public class AccountProfile : Profile
+public sealed class AccountProfile : Profile
 {
     public AccountProfile()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/RoleProfile.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/RoleProfile.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Shared.Models.Roles;
 
 namespace SocialEventManager.BLL.MappingProfiles;
 
-public class RoleProfile : Profile
+public sealed class RoleProfile : Profile
 {
     public RoleProfile()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/UserProfile.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/MappingProfiles/Obsolete/UserProfile.cs
@@ -11,7 +11,7 @@ using SocialEventManager.Shared.Models.Users;
 
 namespace SocialEventManager.BLL.MappingProfiles;
 
-public class UserProfile : Profile
+public sealed class UserProfile : Profile
 {
     public UserProfile()
     {

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Auth/AuthService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Auth/AuthService.cs
@@ -14,7 +14,7 @@ using SocialEventManager.Shared.Models.Email;
 
 namespace SocialEventManager.BLL.Services;
 
-public class AuthService : IAuthService
+public sealed class AuthService : IAuthService
 {
     private readonly IConfiguration _config;
     private readonly IJwtHandler _jwtHandler;

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Contact/ContactService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Contact/ContactService.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Shared.Models.Email;
 
 namespace SocialEventManager.BLL.Services.Contact;
 
-public class ContactService : IContactService
+public sealed class ContactService : IContactService
 {
     private readonly IEmailService _emailService;
     private readonly IMapper _mapper;

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Email/RazorEmailRenderer.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Email/RazorEmailRenderer.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Shared.Constants.Validations;
 
 namespace SocialEventManager.BLL.Services.Email;
 
-public class RazorEmailRenderer : IEmailRenderer
+public sealed class RazorEmailRenderer : IEmailRenderer
 {
     private readonly IRazorViewEngine _razorViewEngine;
     private readonly ITempDataProvider _tempDataProvider;

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Accounts/AccountsService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Accounts/AccountsService.cs
@@ -16,7 +16,7 @@ using SocialEventManager.Shared.Models.Users;
 
 namespace SocialEventManager.BLL.Services.Accounts;
 
-public class AccountsService : ServiceBase<IAccountsRepository, Account>, IAccountsService
+public sealed class AccountsService : ServiceBase<IAccountsRepository, Account>, IAccountsService
 {
     private readonly IUserClaimsService _userClaimsService;
     private readonly IUserRolesService _userRolesService;

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Identity/CustomRolesStore.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Identity/CustomRolesStore.cs
@@ -13,7 +13,7 @@ using SocialEventManager.Shared.Models.Roles;
 
 namespace SocialEventManager.BLL.Services.Identity;
 
-public class CustomRolesStore : IRoleStore<ApplicationRole>
+public sealed class CustomRolesStore : IRoleStore<ApplicationRole>
 {
     private readonly IRolesService _rolesService;
     private readonly IUnitOfWork _unitOfWork;

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Identity/CustomUsersStore.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Identity/CustomUsersStore.cs
@@ -18,7 +18,7 @@ using SocialEventManager.Shared.Models.Users;
 
 namespace SocialEventManager.BLL.Services.Identity;
 
-public class CustomUsersStore :
+public sealed class CustomUsersStore :
     IUserPasswordStore<ApplicationUser>,
     IUserEmailStore<ApplicationUser>,
     IUserRoleStore<ApplicationUser>,

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Roles/RolesService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Roles/RolesService.cs
@@ -14,7 +14,7 @@ using SocialEventManager.Shared.Models.Roles;
 
 namespace SocialEventManager.BLL.Services.Roles;
 
-public class RolesService : ServiceBase<IRolesRepository, Role>, IRolesService
+public sealed class RolesService : ServiceBase<IRolesRepository, Role>, IRolesService
 {
     public RolesService(IRolesRepository rolesRepository, IMapper mapper)
         : base(rolesRepository, mapper)

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Users/UserClaimsService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Users/UserClaimsService.cs
@@ -16,7 +16,7 @@ using SocialEventManager.Shared.Models.Users;
 
 namespace SocialEventManager.BLL.Services.Users;
 
-public class UserClaimsService : ServiceBase<IUserClaimsRepository, UserClaim>, IUserClaimsService
+public sealed class UserClaimsService : ServiceBase<IUserClaimsRepository, UserClaim>, IUserClaimsService
 {
     public UserClaimsService(IUserClaimsRepository userClaimsRepository, IUnitOfWork unitOfWork, IMapper mapper)
         : base(userClaimsRepository, unitOfWork, mapper)

--- a/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Users/UserRolesService.cs
+++ b/SocialEventManager/src/SocialEventManager.BLL/Services/Obsolete/Users/UserRolesService.cs
@@ -14,7 +14,7 @@ using SocialEventManager.Shared.Models.Users;
 
 namespace SocialEventManager.BLL.Services.Users;
 
-public class UserRolesService : ServiceBase<IUserRolesRepository, UserRole>, IUserRolesService
+public sealed class UserRolesService : ServiceBase<IUserRolesRepository, UserRole>, IUserRolesService
 {
     private readonly IRolesService _rolesService;
 

--- a/SocialEventManager/src/SocialEventManager.DAL/Migrations/DbMigrations.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Migrations/DbMigrations.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Shared.Constants;
 
 namespace SocialEventManager.DAL.Migrations;
 
-public class DbMigrations
+public sealed class DbMigrations
 {
     private readonly IConfiguration _config;
 

--- a/SocialEventManager/src/SocialEventManager.DAL/Migrations/EnumLookupTableCreator.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Migrations/EnumLookupTableCreator.cs
@@ -11,7 +11,7 @@ using SocialEventManager.Shared.Utilities.Attributes;
 
 namespace SocialEventManager.DAL.Migrations;
 
-public class EnumLookupTableCreator
+public sealed class EnumLookupTableCreator
 {
     private const string TypeName = "LoadedValues";
     private readonly SqlConnection _connection;

--- a/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Accounts/AccountsRepository.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Accounts/AccountsRepository.cs
@@ -8,7 +8,7 @@ using SocialEventManager.Shared.Entities;
 
 namespace SocialEventManager.DAL.Repositories.Accounts;
 
-public class AccountsRepository : GenericRepository<Account>, IAccountsRepository
+public sealed class AccountsRepository : GenericRepository<Account>, IAccountsRepository
 {
     public AccountsRepository(IDbSession session)
         : base(session)

--- a/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Roles/RolesRepository.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Roles/RolesRepository.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Shared.Entities;
 
 namespace SocialEventManager.DAL.Repositories.Roles;
 
-public class RolesRepository : GenericRepository<Role>, IRolesRepository
+public sealed class RolesRepository : GenericRepository<Role>, IRolesRepository
 {
     private readonly IDbSession _session;
 

--- a/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Users/UserClaimsRepository.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Users/UserClaimsRepository.cs
@@ -11,7 +11,7 @@ using SocialEventManager.Shared.Entities;
 
 namespace SocialEventManager.DAL.Repositories.Users;
 
-public class UserClaimsRepository : GenericRepository<UserClaim>, IUserClaimsRepository
+public sealed class UserClaimsRepository : GenericRepository<UserClaim>, IUserClaimsRepository
 {
     private readonly IDbSession _session;
 

--- a/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Users/UserRolesRepository.cs
+++ b/SocialEventManager/src/SocialEventManager.DAL/Repositories/Obsolete/Users/UserRolesRepository.cs
@@ -11,7 +11,7 @@ using SocialEventManager.Shared.Entities;
 
 namespace SocialEventManager.DAL.Repositories.Users;
 
-public class UserRolesRepository : GenericRepository<UserRole>, IUserRolesRepository
+public sealed class UserRolesRepository : GenericRepository<UserRole>, IUserRolesRepository
 {
     private readonly IDbSession _session;
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Attributes/TrackPerformanceAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Attributes/TrackPerformanceAttribute.cs
@@ -5,7 +5,7 @@ using SocialEventManager.Infrastructure.Loggers;
 
 namespace SocialEventManager.Infrastructure.Attributes;
 
-public class TrackPerformanceAttribute : ActionFilterAttribute
+public sealed class TrackPerformanceAttribute : ActionFilterAttribute
 {
     private readonly ILogger<TrackPerformanceAttribute> _logger;
     private readonly Stopwatch _timer;

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Attributes/ValidationFilterAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Attributes/ValidationFilterAttribute.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Constants.Validations;
 
 namespace SocialEventManager.Infrastructure.Attributes;
 
-public class ValidationFilterAttribute : IAsyncActionFilter
+public sealed class ValidationFilterAttribute : IAsyncActionFilter
 {
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Auth/JwtHandler.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Auth/JwtHandler.cs
@@ -7,7 +7,7 @@ using SocialEventManager.Shared.Configurations;
 
 namespace SocialEventManager.Infrastructure.Auth;
 
-public class JwtHandler : IJwtHandler
+public sealed class JwtHandler : IJwtHandler
 {
     private readonly JwtConfiguration _jwtConfiguration;
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Email/EmailService.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Email/EmailService.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Shared.Models.Email;
 
 namespace SocialEventManager.Infrastructure.Email;
 
-public class EmailService : IEmailService
+public sealed class EmailService : IEmailService
 {
     private readonly EmailConfiguration _emailConfiguration;
     private readonly IEmailProvider _emailProvider;

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Email/EmailSmtpProvider.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Email/EmailSmtpProvider.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Shared.Configurations;
 
 namespace SocialEventManager.Infrastructure.Email;
 
-public class EmailSmtpProvider : IEmailProvider
+public sealed class EmailSmtpProvider : IEmailProvider
 {
     private const int Port = 587;
     private readonly EmailConfiguration _emailConfiguration;

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireApplyStateEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireApplyStateEventsLogAttribute.cs
@@ -5,7 +5,7 @@ using Hangfire.Storage;
 
 namespace SocialEventManager.Infrastructure.Filters.BackgroundJobs;
 
-public class HangfireApplyStateEventsLogAttribute : JobFilterAttribute, IApplyStateFilter
+public sealed class HangfireApplyStateEventsLogAttribute : JobFilterAttribute, IApplyStateFilter
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireClientEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireClientEventsLogAttribute.cs
@@ -4,7 +4,7 @@ using Hangfire.Logging;
 
 namespace SocialEventManager.Infrastructure.Filters.BackgroundJobs;
 
-public class HangfireClientEventsLogAttribute : JobFilterAttribute, IClientFilter
+public sealed class HangfireClientEventsLogAttribute : JobFilterAttribute, IClientFilter
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireElectStateEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireElectStateEventsLogAttribute.cs
@@ -4,7 +4,7 @@ using Hangfire.States;
 
 namespace SocialEventManager.Infrastructure.Filters.BackgroundJobs;
 
-public class HangfireElectStateEventsLogAttribute : JobFilterAttribute, IElectStateFilter
+public sealed class HangfireElectStateEventsLogAttribute : JobFilterAttribute, IElectStateFilter
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireServerEventsLogAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/BackgroundJobs/HangfireServerEventsLogAttribute.cs
@@ -4,7 +4,7 @@ using Hangfire.Server;
 
 namespace SocialEventManager.Infrastructure.Filters.BackgroundJobs;
 
-public class HangfireServerEventsLogAttribute : JobFilterAttribute, IServerFilter
+public sealed class HangfireServerEventsLogAttribute : JobFilterAttribute, IServerFilter
 {
     private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/TrackActionPerformanceFilter.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Filters/TrackActionPerformanceFilter.cs
@@ -5,7 +5,7 @@ using SocialEventManager.Infrastructure.Loggers;
 
 namespace SocialEventManager.Infrastructure.Filters;
 
-public class TrackActionPerformanceFilter : IActionFilter
+public sealed class TrackActionPerformanceFilter : IActionFilter
 {
     private readonly ILogger<TrackActionPerformanceFilter> _logger;
     private Stopwatch _timer = default!;

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Identity/ApplicationDbContext.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Identity/ApplicationDbContext.cs
@@ -12,7 +12,7 @@ namespace SocialEventManager.Infrastructure.Identity;
 using SocialEventManager.Shared.Constants;
 
 [ExcludeFromCodeCoverage]
-public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
+public sealed class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Loggers/ScopeInformation.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Loggers/ScopeInformation.cs
@@ -3,7 +3,7 @@ using SocialEventManager.Shared.Constants;
 
 namespace SocialEventManager.Infrastructure.Loggers;
 
-public class ScopeInformation : IScopeInformation
+public sealed class ScopeInformation : IScopeInformation
 {
     public ScopeInformation()
     {

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiError.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiError.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Infrastructure.Middleware;
 
-public class ApiError
+public sealed class ApiError
 {
     public string Id { get; set; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiErrorData.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiErrorData.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Infrastructure.Middleware;
 
-public class ApiErrorData
+public sealed class ApiErrorData
 {
     public ApiErrorData(string detail)
     {

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionMiddleware.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionMiddleware.cs
@@ -8,7 +8,7 @@ using SocialEventManager.Shared.Extensions;
 
 namespace SocialEventManager.Infrastructure.Middleware;
 
-public class ApiExceptionMiddleware
+public sealed class ApiExceptionMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ApiExceptionOptions _options;

--- a/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionOptions.cs
+++ b/SocialEventManager/src/SocialEventManager.Infrastructure/Middleware/ApiExceptionOptions.cs
@@ -3,7 +3,7 @@ using Serilog.Events;
 
 namespace SocialEventManager.Infrastructure.Middleware;
 
-public class ApiExceptionOptions
+public sealed class ApiExceptionOptions
 {
     public Action<HttpContext, Exception, ApiError> AddResponseDetails { get; set; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.Shared/Configurations/EmailConfiguration.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Configurations/EmailConfiguration.cs
@@ -2,7 +2,7 @@ using SocialEventManager.Shared.Constants;
 
 namespace SocialEventManager.Shared.Configurations;
 
-public class EmailConfiguration
+public sealed class EmailConfiguration
 {
     private readonly string _userName = null!;
     private readonly string _password = null!;

--- a/SocialEventManager/src/SocialEventManager.Shared/Configurations/HangfireSettingsConfiguration.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Configurations/HangfireSettingsConfiguration.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Shared.Configurations;
 
-public class HangfireSettingsConfiguration
+public sealed class HangfireSettingsConfiguration
 {
     private readonly string _userName = null!;
     private readonly string _password = null!;

--- a/SocialEventManager/src/SocialEventManager.Shared/Configurations/JwtConfiguration.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Configurations/JwtConfiguration.cs
@@ -2,7 +2,7 @@ using SocialEventManager.Shared.Constants;
 
 namespace SocialEventManager.Shared.Configurations;
 
-public class JwtConfiguration
+public sealed class JwtConfiguration
 {
     private readonly string _key = null!;
     private readonly string _expiryInDays = null!;

--- a/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/Account.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/Account.cs
@@ -14,7 +14,7 @@ using Dapper.Contrib.Extensions;
 [Alias(nameof(TableNameConstants.Accounts))]
 [UniqueConstraint(nameof(Email))]
 [UniqueConstraint(nameof(UserId))]
-public class Account
+public sealed class Account
 {
     [Computed]
     [AutoIncrement]

--- a/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/Role.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/Role.cs
@@ -7,7 +7,7 @@ namespace SocialEventManager.Shared.Entities;
 [Table(TableNameConstants.Roles)]
 [Alias(nameof(TableNameConstants.Roles))]
 [UniqueConstraint(nameof(Name))]
-public class Role
+public sealed class Role
 {
     [Required]
     [ExplicitKey]

--- a/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/UserClaim.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/UserClaim.cs
@@ -12,7 +12,7 @@ namespace SocialEventManager.Shared.Entities;
 [Table(TableNameConstants.UserClaims)]
 [Alias(nameof(TableNameConstants.UserClaims))]
 [UniqueConstraint(nameof(UserId), nameof(Type))]
-public class UserClaim : ClaimBase
+public sealed class UserClaim : ClaimBase
 {
     [Required]
     [ForeignKey(typeof(Account), OnDelete = GlobalConstants.Cascade)]

--- a/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/UserRole.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Entities/Obsolete/UserRole.cs
@@ -13,7 +13,7 @@ using Dapper.Contrib.Extensions;
 [Table(TableNameConstants.UserRoles)]
 [Alias(nameof(TableNameConstants.UserRoles))]
 [UniqueConstraint(nameof(UserId), nameof(RoleId))]
-public class UserRole
+public sealed class UserRole
 {
     [Computed]
     [PrimaryKey]

--- a/SocialEventManager/src/SocialEventManager.Shared/EqualityComparers/Obsolete/UserClaimEqualityComparer.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/EqualityComparers/Obsolete/UserClaimEqualityComparer.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Shared.Helpers;
 
 namespace SocialEventManager.Shared.EqualityComparers;
 
-public class UserClaimEqualityComparer : IEqualityComparer<UserClaim>
+public sealed class UserClaimEqualityComparer : IEqualityComparer<UserClaim>
 {
     public bool Equals(UserClaim? userClaim, UserClaim? otherUserClaim)
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Exceptions/BadRequestException.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Exceptions/BadRequestException.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Shared.Exceptions;
 
-public class BadRequestException : ApplicationException
+public sealed class BadRequestException : ApplicationException
 {
     public BadRequestException()
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Exceptions/NotFoundException.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Exceptions/NotFoundException.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Shared.Exceptions;
 
-public class NotFoundException : ApplicationException
+public sealed class NotFoundException : ApplicationException
 {
     public NotFoundException()
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Exceptions/UnprocessableEntityException.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Exceptions/UnprocessableEntityException.cs
@@ -1,6 +1,6 @@
 namespace SocialEventManager.Shared.Exceptions;
 
-public class UnprocessableEntityException : ApplicationException
+public sealed class UnprocessableEntityException : ApplicationException
 {
     public UnprocessableEntityException()
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Models/Auth/ApplicationUser.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Models/Auth/ApplicationUser.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace SocialEventManager.Shared.Models.Auth;
 
-public class ApplicationUser : IdentityUser<Guid>
+public sealed class ApplicationUser : IdentityUser<Guid>
 {
     public string FirstName { get; set; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.Shared/Models/Identity/Obsolete/ApplicationRole.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Models/Identity/Obsolete/ApplicationRole.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Shared.Models.Identity;
 /// <summary>
 /// The role.
 /// </summary>
-public class ApplicationRole : IdentityRole
+public sealed class ApplicationRole : IdentityRole
 {
     public ApplicationRole()
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Models/Identity/Obsolete/ApplicationUser.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Models/Identity/Obsolete/ApplicationUser.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace SocialEventManager.Shared.Models.Identity;
 
-public class ApplicationUser : IdentityUser
+public sealed class ApplicationUser : IdentityUser
 {
     public string AuthenticationType { get; set; } = null!;
 

--- a/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/DbEntityAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/DbEntityAttribute.cs
@@ -3,7 +3,7 @@ using SocialEventManager.DAL.Utilities.Enums;
 namespace SocialEventManager.Shared.Utilities.Attributes;
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
-public class DbEntityAttribute : Attribute
+public sealed class DbEntityAttribute : Attribute
 {
     public DbEntityAttribute(DbTypes dbTypes)
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/EnumTableAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/EnumTableAttribute.cs
@@ -1,7 +1,7 @@
 namespace SocialEventManager.Shared.Utilities.Attributes;
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
-public class EnumTableAttribute : Attribute
+public sealed class EnumTableAttribute : Attribute
 {
     public EnumTableAttribute(string tableName)
     {

--- a/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/NotDefaultAttribute.cs
+++ b/SocialEventManager/src/SocialEventManager.Shared/Utilities/Attributes/NotDefaultAttribute.cs
@@ -4,7 +4,7 @@ using SocialEventManager.Shared.Constants.Validations;
 namespace SocialEventManager.Shared.Utilities.Attributes;
 
 [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
-public class NotDefaultAttribute : ValidationAttribute
+public sealed class NotDefaultAttribute : ValidationAttribute
 {
     public NotDefaultAttribute()
         : base(ValidationConstants.TheFieldMustNotHaveTheDefaultValue)

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/DataMembers/Storages/BackgroundJobStorage.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/DataMembers/Storages/BackgroundJobStorage.cs
@@ -2,7 +2,7 @@ using SocialEventManager.Shared.Enums;
 
 namespace SocialEventManager.Tests.Common.DataMembers.Storages;
 
-internal class BackgroundJobStorage : DictionaryStorage<BackgroundJobStorage, BackgroundJobType, bool>
+internal sealed class BackgroundJobStorage : DictionaryStorage<BackgroundJobStorage, BackgroundJobType, bool>
 {
     public override void Init()
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/ApplyStateContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/ApplyStateContextMock.cs
@@ -5,7 +5,7 @@ using Moq;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class ApplyStateContextMock
+internal sealed class ApplyStateContextMock
 {
     private readonly Lazy<ApplyStateContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/BackgroundJobMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/BackgroundJobMock.cs
@@ -3,7 +3,7 @@ using Hangfire.Common;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class BackgroundJobMock
+internal sealed class BackgroundJobMock
 {
     private readonly Lazy<BackgroundJob> _object;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreateContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreateContextMock.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class CreateContextMock
+internal sealed class CreateContextMock
 {
     private readonly Lazy<CreateContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreatedContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreatedContextMock.cs
@@ -2,7 +2,7 @@ using Hangfire.Client;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class CreatedContextMock
+internal sealed class CreatedContextMock
 {
     private readonly Lazy<CreatedContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreatingContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/CreatingContextMock.cs
@@ -2,7 +2,7 @@ using Hangfire.Client;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class CreatingContextMock
+internal sealed class CreatingContextMock
 {
     private readonly Lazy<CreatingContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/ElectStateContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/ElectStateContextMock.cs
@@ -2,7 +2,7 @@ using Hangfire.States;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class ElectStateContextMock
+internal sealed class ElectStateContextMock
 {
     private readonly Lazy<ElectStateContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/PerformContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/PerformContextMock.cs
@@ -5,7 +5,7 @@ using Moq;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class PerformContextMock
+internal sealed class PerformContextMock
 {
     private readonly Lazy<PerformContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/PerformedContextMock.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Common/Mocks/PerformedContextMock.cs
@@ -2,7 +2,7 @@ using Hangfire.Server;
 
 namespace SocialEventManager.Tests.Common.Mocks;
 
-internal class PerformedContextMock
+internal sealed class PerformedContextMock
 {
     private readonly Lazy<PerformedContext> _context;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/AccountsControllerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/AccountsControllerTests.cs
@@ -24,7 +24,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests;
 [Collection(TestConstants.StorageDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class AccountsControllerTests : IntegrationTest
+public sealed class AccountsControllerTests : IntegrationTest
 {
     public AccountsControllerTests(ApiWebApplicationFactory fixture, IJwtHandler jwtHandler)
       : base(fixture, jwtHandler)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/ContactControllerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/ContactControllerTests.cs
@@ -21,7 +21,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests;
 [Collection(TestConstants.StorageDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Contacts)]
-public class ContactControllerTests : IntegrationTest
+public sealed class ContactControllerTests : IntegrationTest
 {
     public ContactControllerTests(ApiWebApplicationFactory fixture, IJwtHandler jwtHandler)
       : base(fixture, jwtHandler)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/HealthCheckTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/HealthCheckTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests;
 
 [IntegrationTest]
 [Category(CategoryConstants.HealthChecks)]
-public class HealthCheckTests : IntegrationTest
+public sealed class HealthCheckTests : IntegrationTest
 {
     public HealthCheckTests(ApiWebApplicationFactory fixture, IJwtHandler jwtHandler)
       : base(fixture, jwtHandler)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/Obsolete/AccountsControllerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/Obsolete/AccountsControllerTests.cs
@@ -24,7 +24,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests;
 [Collection(TestConstants.StorageDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class AccountsControllerTests : IntegrationTest
+public sealed class AccountsControllerTests : IntegrationTest
 {
     public AccountsControllerTests(ApiWebApplicationFactory fixture)
       : base(fixture)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/Obsolete/RolesControllerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/ControllerTests/Obsolete/RolesControllerTests.cs
@@ -26,7 +26,7 @@ namespace SocialEventManager.Tests.IntegrationTests.ControllerTests;
 [Collection(TestConstants.StorageDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class RolesControllerTests : IntegrationTest
+public sealed class RolesControllerTests : IntegrationTest
 {
     public RolesControllerTests(ApiWebApplicationFactory fixture)
       : base(fixture)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/EqualityComparerTests/Obsolete/UserClaimEqualityComparerTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/EqualityComparerTests/Obsolete/UserClaimEqualityComparerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace SocialEventManager.Tests.IntegrationTests.EqualityComparerTests;
 
-public class UserClaimEqualityComparerTests
+public sealed class UserClaimEqualityComparerTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/ApiWebApplicationFactory.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/ApiWebApplicationFactory.cs
@@ -6,7 +6,7 @@ using SocialEventManager.Tests.Common.DependencyInjection;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures;
 
-public class ApiWebApplicationFactory : WebApplicationFactory<Program>
+public sealed class ApiWebApplicationFactory : WebApplicationFactory<Program>
 {
     public IConfiguration Configuration { get; private set; } = null!;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/FakeSignInManager.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/FakeSignInManager.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Tests.Common.DataMembers.Storages.Identity;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-public class FakeSignInManager : SignInManager<ApplicationUser>
+public sealed class FakeSignInManager : SignInManager<ApplicationUser>
 {
     private readonly IPasswordHasher<ApplicationUser> _passwordHasher;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/FakeUserManager.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/FakeUserManager.cs
@@ -8,7 +8,7 @@ using SocialEventManager.Tests.Common.DataMembers.Storages.Identity;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-public class FakeUserManager : UserManager<ApplicationUser>
+public sealed class FakeUserManager : UserManager<ApplicationUser>
 {
     private readonly IPasswordHasher<ApplicationUser> _passwordHasher;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeAccounts.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeAccounts.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-internal class FakeAccounts : StubBase<Account>, IAccountsRepository
+internal sealed class FakeAccounts : StubBase<Account>, IAccountsRepository
 {
     public override Task<Account?> GetSingleOrDefaultAsync<TFilter>(TFilter filterValue, string columnName)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeRoles.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeRoles.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-internal class FakeRoles : StubBase<Role>, IRolesRepository
+internal sealed class FakeRoles : StubBase<Role>, IRolesRepository
 {
     public Task<Guid> InsertRole(Role role)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeUserClaims.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeUserClaims.cs
@@ -10,7 +10,7 @@ using SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-internal class FakeUserClaims : StubBase<UserClaim>, IUserClaimsRepository
+internal sealed class FakeUserClaims : StubBase<UserClaim>, IUserClaimsRepository
 {
     public override Task InsertAsync(IEnumerable<UserClaim> userClaims)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeUserRoles.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Fakes/Obsolete/FakeUserRoles.cs
@@ -12,7 +12,7 @@ using SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Fakes;
 
-internal class FakeUserRoles : StubBase<UserRole>, IUserRolesRepository
+internal sealed class FakeUserRoles : StubBase<UserRole>, IUserRolesRepository
 {
     public Task<int> InsertAsync(Guid userId, string roleName)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/Obsolete/StubInvalidRoles.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/Obsolete/StubInvalidRoles.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Tests.Common.DataMembers.Storages;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
-internal class StubInvalidRoles : StubBase<Role>, IRolesRepository
+internal sealed class StubInvalidRoles : StubBase<Role>, IRolesRepository
 {
     public Task<IEnumerable<Role>> GetByUserIdAsync(Guid userId) => Task.FromResult<IEnumerable<Role>>(null!);
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/StubEmailSmtpProvider.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/StubEmailSmtpProvider.cs
@@ -7,7 +7,7 @@ using SocialEventManager.Tests.Common.Helpers;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
-internal class StubEmailSmtpProvider : IEmailProvider
+internal sealed class StubEmailSmtpProvider : IEmailProvider
 {
     public async Task SendEmailAsync(MimeMessage message)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/StubSmtpClient.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Fixtures/Stubs/StubSmtpClient.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Tests.Common.Helpers;
 
 namespace SocialEventManager.Tests.IntegrationTests.Fixtures.Stubs;
 
-internal class StubSmtpClient : SmtpClient, ISmtpClient
+internal sealed class StubSmtpClient : SmtpClient, ISmtpClient
 {
     public new Task AuthenticateAsync(string userName, string password, CancellationToken cancellationToken = default)
     {

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Infrastructure/InMemoryDatabase.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/Infrastructure/InMemoryDatabase.cs
@@ -9,7 +9,7 @@ using SocialEventManager.Shared.Extensions;
 
 namespace SocialEventManager.Tests.IntegrationTests.Infrastructure;
 
-public class InMemoryDatabase : IInMemoryDatabase
+public sealed class InMemoryDatabase : IInMemoryDatabase
 {
     private readonly OrmLiteConnectionFactory _dbFactory;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/DbSessionTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/DbSessionTests.cs
@@ -12,7 +12,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests;
 
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class DbSessionTests
+public sealed class DbSessionTests
 {
     private readonly IConfiguration _configuration;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/EmailTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/EmailTests.cs
@@ -20,7 +20,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests;
 [Collection(TestConstants.StorageDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class EmailTests
+public sealed class EmailTests
 {
     [Theory]
     [MemberData(nameof(EmailData.EmailMessage), MemberType = typeof(EmailData))]

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/RedisCacheClientTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/RedisCacheClientTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests;
 
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class RedisCacheClientTests
+public sealed class RedisCacheClientTests
 {
     private readonly IRedisClientsManagerAsync _manager;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/SqlMapperUtilitiesTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/InfrastructureTests/SqlMapperUtilitiesTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.IntegrationTests.InfrastructureTests;
 
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class SqlMapperUtilitiesTests
+public sealed class SqlMapperUtilitiesTests
 {
     [Fact]
     public void GetTableName_Should_ReturnTableName_When_ClassHasTableAttribute()

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/ExtendedRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/ExtendedRepositoryTests.cs
@@ -18,7 +18,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class ExtendedRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
+public sealed class ExtendedRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
 {
     public ExtendedRepositoryTests(IInMemoryDatabase db, IRolesRepository rolesRepository)
         : base(db, rolesRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/GenericRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/GenericRepositoryTests.cs
@@ -16,7 +16,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Infrastructure)]
-public class GenericRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
+public sealed class GenericRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
 {
     public GenericRepositoryTests(IInMemoryDatabase db, IRolesRepository rolesRepository)
         : base(db, rolesRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/AccountsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/AccountsRepositoryTests.cs
@@ -19,7 +19,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class AccountsRepositoryTests : RepositoryTestBase<IAccountsRepository, Account>
+public sealed class AccountsRepositoryTests : RepositoryTestBase<IAccountsRepository, Account>
 {
     public AccountsRepositoryTests(IInMemoryDatabase db, IAccountsRepository accountsRepository)
         : base(db, accountsRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/RolesRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/RolesRepositoryTests.cs
@@ -20,7 +20,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class RolesRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
+public sealed class RolesRepositoryTests : RepositoryTestBase<IRolesRepository, Role>
 {
     public RolesRepositoryTests(IInMemoryDatabase db, IRolesRepository rolesRepository)
         : base(db, rolesRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/UserClaimsRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/UserClaimsRepositoryTests.cs
@@ -22,7 +22,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class UserClaimsRepositoryTests : RepositoryTestBase<IUserClaimsRepository, UserClaim>
+public sealed class UserClaimsRepositoryTests : RepositoryTestBase<IUserClaimsRepository, UserClaim>
 {
     public UserClaimsRepositoryTests(IInMemoryDatabase db, IUserClaimsRepository userClaimsRepository)
         : base(db, userClaimsRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/UserRolesRepositoryTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/IntegrationTests/RepositoryTests/Obsolete/UserRolesRepositoryTests.cs
@@ -22,7 +22,7 @@ namespace SocialEventManager.Tests.IntegrationTests.RepositoryTests;
 [Collection(TestConstants.DatabaseDependent)]
 [IntegrationTest]
 [Category(CategoryConstants.Identity)]
-public class UserRolesRepositoryTests : RepositoryTestBase<IUserRolesRepository, UserRole>
+public sealed class UserRolesRepositoryTests : RepositoryTestBase<IUserRolesRepository, UserRole>
 {
     public UserRolesRepositoryTests(IInMemoryDatabase db, IUserRolesRepository userRolesRepository)
         : base(db, userRolesRepository)

--- a/SocialEventManager/tests/SocialEventManager.Tests/Startup.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/Startup.cs
@@ -13,7 +13,7 @@ using Xunit.DependencyInjection.Logging;
 
 namespace SocialEventManager.Tests;
 
-public class Startup
+public sealed class Startup
 {
     public IConfiguration Configuration { get; set; } = null!;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireApplyStateEventsLogAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireApplyStateEventsLogAttributeTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class HangfireApplyStateEventsLogAttributeTests
+public sealed class HangfireApplyStateEventsLogAttributeTests
 {
     [Fact]
     public void OnStateApplied_Should_NotThrowException_When_Called()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireClientEventsLogAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireClientEventsLogAttributeTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class HangfireClientEventsLogAttributeTests
+public sealed class HangfireClientEventsLogAttributeTests
 {
     [Fact]
     public void OnCreating_Should_NotThrowException_When_Called()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireElectStateEventsLogAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireElectStateEventsLogAttributeTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class HangfireElectStateEventsLogAttributeTests
+public sealed class HangfireElectStateEventsLogAttributeTests
 {
     [Fact]
     public void OnStateElection_Should_NotThrowException_When_CandidateStateIsSuccees()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireServerEventsLogAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/HangfireServerEventsLogAttributeTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class HangfireServerEventsLogAttributeTests
+public sealed class HangfireServerEventsLogAttributeTests
 {
     [Fact]
     public void OnPerforming_Should_NotThrowException_When_Called()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/NotDefaultAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/NotDefaultAttributeTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class NotDefaultAttributeTests
+public sealed class NotDefaultAttributeTests
 {
     [Theory]
     [InlineData(null, true)]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/RequestHeaderMatchesMediaTypeAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/RequestHeaderMatchesMediaTypeAttributeTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class RequestHeaderMatchesMediaTypeAttributeTests
+public sealed class RequestHeaderMatchesMediaTypeAttributeTests
 {
     [Theory]
     [InlineData(null, null, new string[] { }, "requestHeaderToMatch")]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/TrackPerformanceAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/TrackPerformanceAttributeTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class TrackPerformanceAttributeTests
+public sealed class TrackPerformanceAttributeTests
 {
     private readonly ILogger<TrackPerformanceAttribute> _logger;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/ValidationFilterAttributeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/AttributeTests/ValidationFilterAttributeTests.cs
@@ -13,7 +13,7 @@ namespace SocialEventManager.Tests.UnitTests.AttributeTests;
 
 [UnitTest]
 [Category(CategoryConstants.Attributes)]
-public class ValidationFilterAttributeTests
+public sealed class ValidationFilterAttributeTests
 {
     [Fact]
     public async Task Init_Should_ReturnNullResult_When_ArgumentsAreValid()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerableExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerableExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class EnumerableExtensionsTests
+public sealed class EnumerableExtensionsTests
 {
     [Theory]
     [MemberData(nameof(EnumerableData.EmptyData), MemberType = typeof(EnumerableData))]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerationExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/EnumerationExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class EnumerationExtensionsTests
+public sealed class EnumerationExtensionsTests
 {
     [Theory]
     [InlineData(RoleType.Admin, "Admin")]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ExceptionExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ExceptionExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class ExceptionExtensionsTests
+public sealed class ExceptionExtensionsTests
 {
     [Theory]
     [MemberData(nameof(ExceptionData.ExceptionDataForHttpStatusAndTitle), MemberType = typeof(ExceptionData))]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/GuidExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/GuidExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class GuidExtensionsTests
+public sealed class GuidExtensionsTests
 {
     private const int Base64LengthWithoutEquals = 22;
     private const string EmptyBase64 = "AAAAAAAAAAAAAAAAAAAAAA";

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ParallelExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ParallelExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class ParallelExtensionsTests
+public sealed class ParallelExtensionsTests
 {
     private int counter = 1;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ResultExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/ResultExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class ResultExtensionsTests
+public sealed class ResultExtensionsTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/SignInResultExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/SignInResultExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class SignInResultExtensionsTests
+public sealed class SignInResultExtensionsTests
 {
     [Theory]
     [MemberData(nameof(SignInResultData.SignInResultToUserLoginResult), MemberType = typeof(SignInResultData))]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/StringExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/StringExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
 [UnitTest]
 [Category(CategoryConstants.Extensions)]
-public class StringExtensionsTests
+public sealed class StringExtensionsTests
 {
     [Theory]
     [MemberData(nameof(StringData.NullOrEmptyData), MemberType = typeof(StringData))]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/TypeExtensionsTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/ExtensionTests/TypeExtensionsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace SocialEventManager.Tests.UnitTests.ExtensionTests;
 
-public class TypeExtensionsTests
+public sealed class TypeExtensionsTests
 {
     [Fact]
     public void GetNonPublicStaticMethod_Should_ReturnMethod_When_MethodNameExists()

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/FilterTests/TrackActionPerformanceFilterTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/FilterTests/TrackActionPerformanceFilterTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.FilterTests;
 
 [UnitTest]
 [Category(CategoryConstants.Filters)]
-public class TrackActionPerformanceFilterTests
+public sealed class TrackActionPerformanceFilterTests
 {
     private readonly ILogger<TrackActionPerformanceFilter> _logger;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentExceptionHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentExceptionHelpersTests.cs
@@ -11,7 +11,7 @@ namespace SocialEventManager.Tests.UnitTests.HelperTests;
 
 [UnitTest]
 [Category(CategoryConstants.Helpers)]
-public class ArgumentExceptionHelpersTests
+public sealed class ArgumentExceptionHelpersTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentNullExceptionHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/ArgumentNullExceptionHelpersTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace SocialEventManager.Tests.UnitTests.HelperTests;
 
-public class ArgumentNullExceptionHelpersTests
+public sealed class ArgumentNullExceptionHelpersTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/HashingHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/HashingHelpersTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.HelperTests;
 
 [UnitTest]
 [Category(CategoryConstants.Helpers)]
-public class HashingHelpersTests
+public sealed class HashingHelpersTests
 {
     [Theory]
     [InlineData(TestConstants.SomeText, TestConstants.LoremIpsum)]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/RandomGeneratorHelpersTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/HelperTests/RandomGeneratorHelpersTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.HelperTests;
 
 [UnitTest]
 [Category(CategoryConstants.Helpers)]
-public class RandomGeneratorHelpersTests
+public sealed class RandomGeneratorHelpersTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/BadRequestExceptionTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/BadRequestExceptionTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.UtilityTests;
 
 [UnitTest]
 [Category(CategoryConstants.Utilities)]
-public class BadRequestExceptionTests
+public sealed class BadRequestExceptionTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/NotFoundExceptionTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/NotFoundExceptionTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.UtilityTests;
 
 [UnitTest]
 [Category(CategoryConstants.Utilities)]
-public class NotFoundExceptionTests
+public sealed class NotFoundExceptionTests
 {
     [Theory]
     [AutoData]

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/RazorEmailRendererTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/RazorEmailRendererTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.UtilityTests;
 
 [UnitTest]
 [Category(CategoryConstants.Utilities)]
-public class RazorEmailRendererTests
+public sealed class RazorEmailRendererTests
 {
     private readonly IEmailRenderer _emailRenderer;
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/SafeTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/SafeTests.cs
@@ -9,7 +9,7 @@ namespace SocialEventManager.Tests.UnitTests.UtilityTests;
 
 [UnitTest]
 [Category(CategoryConstants.Utilities)]
-public class SafeTests
+public sealed class SafeTests
 {
     #region Synchronous
 

--- a/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/UnprocessableEntityExceptionTests.cs
+++ b/SocialEventManager/tests/SocialEventManager.Tests/UnitTests/UtilityTests/UnprocessableEntityExceptionTests.cs
@@ -10,7 +10,7 @@ namespace SocialEventManager.Tests.UnitTests.UtilityTests;
 
 [UnitTest]
 [Category(CategoryConstants.Utilities)]
-public class UnprocessableEntityExceptionTests
+public sealed class UnprocessableEntityExceptionTests
 {
     [Theory]
     [AutoData]


### PR DESCRIPTION
Sealed classes grant performance benefits and I think that classes should be sealed by default. This is a big discussion topic that many people think so.

For more info:
- Read about [performance benefits of sealed class](https://www.meziantou.net/performance-benefits-of-sealed-class.htm).
- Watch [Why all your classes should be sealed by default in C#](https://www.youtube.com/watch?v=d76WWAD99Yo).