### PR TITLE
Reduce memory costs by specifying the list capacity

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/Utilities/Extensions/LoggerExtensions.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Utilities/Extensions/LoggerExtensions.cs
@@ -51,7 +51,7 @@ public static class LoggerExtensions
             return null;
         }
 
-        List<string> excludedClaims = new() { "nbf", "exp", "auth_time", "amr", "sub", "at_hash", "s_hash", "sid", "name", "preferred_username" };
+        List<string> excludedClaims = new(10) { "nbf", "exp", "auth_time", "amr", "sub", "at_hash", "s_hash", "sid", "name", "preferred_username" };
         const string userNameClaimType = "name";
 
         UserInformation userInfo = new()


### PR DESCRIPTION
If the capacity of a list is known, it's recommended to specify it because it reduces memory allocations. An [article](https://dotnetdocs.ir/Post/53/performance-tip-about-list) explaining that.