### PR TITLE
Improve time complexity of iterating through claims

### DIFF
--- a/SocialEventManager/src/SocialEventManager.API/Utilities/Extensions/LoggerExtensions.cs
+++ b/SocialEventManager/src/SocialEventManager.API/Utilities/Extensions/LoggerExtensions.cs
@@ -51,7 +51,7 @@ public static class LoggerExtensions
             return null;
         }
 
-        List<string> excludedClaims = new(10) { "nbf", "exp", "auth_time", "amr", "sub", "at_hash", "s_hash", "sid", "name", "preferred_username" };
+        HashSet<string> excludedClaims = new(10) { "nbf", "exp", "auth_time", "amr", "sub", "at_hash", "s_hash", "sid", "name", "preferred_username" };
         const string userNameClaimType = "name";
 
         UserInformation userInfo = new()
@@ -62,7 +62,7 @@ public static class LoggerExtensions
         };
 
         foreach (string claimType in principal.Claims
-            .Where(c => excludedClaims.All(ec => ec != c.Type))
+            .Where(c => !excludedClaims.Contains(c.Type))
             .Select(c => c.Type)
             .Distinct())
         {


### PR DESCRIPTION
**Before** the change, the time complexity was **O(n^2)** because the code iterated over all the principal claims, and for each claim, it iterated over all the excluded claims.
**After** the change, the time complexity has become **O(n)** because the code iterates over all the principal claims, and for each claim, it accesses a hashed item of the excluded claims which is O(1).