### PR TITLE
Remove Coverlet variables

### DIFF
--- a/SocialEventManager/docker-compose.yml
+++ b/SocialEventManager/docker-compose.yml
@@ -99,8 +99,6 @@ services:
       - Email__UserName=${EMAIL__USERNAME}
       - Email__Password=${EMAIL__PASSWORD}
       - Email__Host=${EMAIL__HOST}
-      - CollectCoverage=true
-      - CoverletOutputFormat=lcov
     volumes:
       - .:/home/runner/work/social-event-manager/social-event-manager/SocialEventManager
       - .:/tests


### PR DESCRIPTION
Those variables were used as a temporarily solution to a regression bug of .NET 7.0.100.

For more info:
- [coverlet.msbuild not working on .net 7](https://github.com/coverlet-coverage/coverlet/issues/1391)
- [dotnet test does not forward MSBuild properties to msbuild in .NET 7 RC1](https://github.com/microsoft/vstest/issues/4014)